### PR TITLE
Close #92: Change default HTTP status from 405 to 403

### DIFF
--- a/core/src/main/java/net/brightroom/featureflag/core/configuration/FeatureFlagProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/configuration/FeatureFlagProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *     hello-class: true
  *     user-find: false
  *   response:
- * #   status-code: 405
+ * #   status-code: 403
  * #   message: "This feature is disabled."
  *   type: JSON
  *   body:

--- a/core/src/main/java/net/brightroom/featureflag/core/configuration/ResponseProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/configuration/ResponseProperties.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public class ResponseProperties {
 
-  Integer statusCode = 405;
+  Integer statusCode = 403;
   ResponseType type = ResponseType.PLAIN_TEXT;
   Map<String, String> body = Map.of("error", "This feature is not available");
   String message = "This feature is not available";

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorJsonResponseIntegrationTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorJsonResponseIntegrationTest.java
@@ -42,7 +42,7 @@ class FeatureFlagInterceptorJsonResponseIntegrationTest {
   void shouldBlockAccess_whenFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/development-stage-endpoint"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(
             content()
                 .json(
@@ -65,7 +65,7 @@ class FeatureFlagInterceptorJsonResponseIntegrationTest {
   void shouldBlockAccess_whenClassLevelFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/test/disable"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(
             content()
                 .json(

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorPlainTextResponseIntegrationTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorPlainTextResponseIntegrationTest.java
@@ -43,7 +43,7 @@ class FeatureFlagInterceptorPlainTextResponseIntegrationTest {
   void shouldBlockAccess_whenFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/development-stage-endpoint"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(content().string("This feature is not available"));
   }
 
@@ -59,7 +59,7 @@ class FeatureFlagInterceptorPlainTextResponseIntegrationTest {
   void shouldBlockAccess_whenClassLevelFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/test/disable"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(content().string("This feature is not available"));
   }
 

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorRFC7807JsonResponseIntegrationTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorRFC7807JsonResponseIntegrationTest.java
@@ -43,7 +43,7 @@ class FeatureFlagInterceptorRFC7807JsonResponseIntegrationTest {
   void shouldBlockAccess_whenFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/development-stage-endpoint"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(
             content()
                 .json(
@@ -55,7 +55,7 @@ class FeatureFlagInterceptorRFC7807JsonResponseIntegrationTest {
                     "properties" : {
                       "error" : "This feature is not available"
                     },
-                    "status" : 405,
+                    "status" : 403,
                     "title" : "Access Denied",
                     "type" : "https://github.com/bright-room/feature-flag-spring-boot-starter"
                   }
@@ -74,7 +74,7 @@ class FeatureFlagInterceptorRFC7807JsonResponseIntegrationTest {
   void shouldBlockAccess_whenClassLevelFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/test/disable"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(
             content()
                 .json(
@@ -86,7 +86,7 @@ class FeatureFlagInterceptorRFC7807JsonResponseIntegrationTest {
                     "properties" : {
                       "error" : "This feature is not available"
                     },
-                    "status" : 405,
+                    "status" : 403,
                     "title" : "Access Denied",
                     "type" : "https://github.com/bright-room/feature-flag-spring-boot-starter"
                   }

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorWebViewResponseIntegrationTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptorWebViewResponseIntegrationTest.java
@@ -69,7 +69,7 @@ class FeatureFlagInterceptorWebViewResponseIntegrationTest {
   void shouldBlockAccess_whenFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/development-stage"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(forwardedUrl("/access-denied"));
   }
 
@@ -94,7 +94,7 @@ class FeatureFlagInterceptorWebViewResponseIntegrationTest {
   void shouldBlockAccess_whenClassLevelFeatureIsDisabled() throws Exception {
     mockMvc
         .perform(get("/test/disable"))
-        .andExpect(status().isMethodNotAllowed())
+        .andExpect(status().isForbidden())
         .andExpect(forwardedUrl("/access-denied"));
   }
 


### PR DESCRIPTION
## Summary

- `ResponseProperties` のデフォルト `statusCode` を `405` から `403` に変更
- フィーチャーフラグによるアクセス拒否は「メソッドが未サポート」ではなく「アクセス権限の欠如」であるため、RFC 9110 の意味論的に正しい `403 Forbidden` を使用する
- 関連するテストコードおよびコメント内のサンプル値も合わせて更新

## Test plan

- [x] `./gradlew :webmvc:test --tests "*.FeatureFlagInterceptorJsonResponseIntegrationTest"` が通ること
- [x] `./gradlew :webmvc:test --tests "*.FeatureFlagInterceptorPlainTextResponseIntegrationTest"` が通ること
- [x] `./gradlew :webmvc:test --tests "*.FeatureFlagInterceptorRFC7807JsonResponseIntegrationTest"` が通ること
- [x] `./gradlew :webmvc:test --tests "*.FeatureFlagInterceptorWebViewResponseIntegrationTest"` が通ること
- [x] `./gradlew test` で全テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)