### PR TITLE
Close #93: Clarify PLAIN_TEXT as default and fix body default

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,9 @@ feature-flags:
     hello-class: true
     user-find: false
   response:
-    status-code: 405
-#    type: PLAIN_TEXT
-#    message: "This feature is disabled."
-    type: JSON
-    body:
-      error: "Feature flag is disabled"
+    status-code: 403
+    type: PLAIN_TEXT  # default
+    message: "This feature is disabled."
 ```
 
 Add the @FeatureFlag annotation to the class or method that will be the endpoint.

--- a/core/src/main/java/net/brightroom/featureflag/core/configuration/ResponseProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/configuration/ResponseProperties.java
@@ -6,7 +6,7 @@ public class ResponseProperties {
 
   Integer statusCode = 403;
   ResponseType type = ResponseType.PLAIN_TEXT;
-  Map<String, String> body = Map.of("error", "This feature is not available");
+  Map<String, String> body = Map.of();
   String message = "This feature is not available";
   ViewProperties view = new ViewProperties();
 

--- a/webmvc/src/test/resources/application.yaml
+++ b/webmvc/src/test/resources/application.yaml
@@ -8,3 +8,5 @@ feature-flags:
     disable-class-level-feature: false
   response:
     type: json
+    body:
+      error: "This feature is not available"


### PR DESCRIPTION
## Summary

- Change default `body` in `ResponseProperties` from a pre-filled map to `Map.of()` — `body` is only meaningful for JSON responses, not the default `PLAIN_TEXT` type
- Add explicit `body` config to webmvc test YAML so tests do not rely on the default body value (the pre-filled default was masking a potential bug)
- Update README configuration example to reflect `PLAIN_TEXT` as the default response type, and correct `status-code` default to `403`

## Test plan

- [x] `./gradlew test` passes (all 20 tasks, including core and webmvc integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)