### PR TITLE
Fix: @FeatureFlag の value をコンパイル時必須に変更

### DIFF
--- a/core/src/main/java/net/brightroom/featureflag/core/annotation/FeatureFlag.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/annotation/FeatureFlag.java
@@ -36,11 +36,11 @@ public @interface FeatureFlag {
    * identifier of the feature flag that determines whether the annotated method or class is
    * accessible or enabled.
    *
-   * <p><b>Important:</b> An empty string value is not permitted. If {@code @FeatureFlag} is applied
-   * without a value (i.e., {@code value} is left as the default empty string), an {@link
-   * IllegalStateException} will be thrown at request time by the interceptor.
+   * <p>This element is required. {@code @FeatureFlag} without a value will result in a compile-time
+   * error. An explicit empty string (e.g., {@code @FeatureFlag("")}) is also not permitted and will
+   * cause an {@link IllegalStateException} to be thrown at request time by the interceptor.
    *
    * @return the identifier of the feature flag; must be a non-empty string
    */
-  String value() default "";
+  String value();
 }


### PR DESCRIPTION
## Summary

`@FeatureFlag` アノテーションの `value()` 要素のデフォルト値 (`""`) を削除し、値の指定をコンパイル時に必須とした。

### 変更内容

- `FeatureFlag.java` — `String value() default ""` → `String value()`

### 解決する問題

従来は `@FeatureFlag`（値なし）で使用しても実行時まで問題が検出されなかった（`InMemoryFeatureFlagProvider` のフェイルオープン設計により暗黙的にアクセスが許可されていた）。

PR #114 で実行時の `IllegalStateException` を追加したが、コンパイル時に検出できる方がより根本的な解決となる。

### 動作比較

| ケース | 変更前 | 変更後 |
|--------|--------|--------|
| `@FeatureFlag`（値なし）| 実行時 `IllegalStateException` | **コンパイルエラー** |
| `@FeatureFlag("")`（空文字列）| 実行時 `IllegalStateException` | 実行時 `IllegalStateException`（変化なし）|
| `@FeatureFlag("my-feature")`| 正常動作 | 正常動作（変化なし）|

`@FeatureFlag("")`（明示的な空文字列）は引き続きインターセプターの `validateAnnotation()` で実行時に検出される。

## Test plan

- [x] `./gradlew check` — Spotless + unit tests + integration tests すべて通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)