### PR TITLE
Refactor: WebMvcConfigurer の実装をネストした @Configuration クラスに分離

### DIFF
--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagMvcInterceptorRegistrationAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagMvcInterceptorRegistrationAutoConfiguration.java
@@ -14,7 +14,7 @@ class FeatureFlagMvcInterceptorRegistrationAutoConfiguration {
   FeatureFlagMvcInterceptorRegistrationAutoConfiguration() {}
 
   @Configuration(proxyBeanMethods = false)
-  static class MvcConfigurer implements WebMvcConfigurer {
+  static class FeatureFlagMvcInterceptorRegistrationConfiguration implements WebMvcConfigurer {
 
     private final FeatureFlagInterceptor featureFlagInterceptor;
     private final FeatureFlagProperties featureFlagProperties;
@@ -34,7 +34,7 @@ class FeatureFlagMvcInterceptorRegistrationAutoConfiguration {
       }
     }
 
-    MvcConfigurer(
+    FeatureFlagMvcInterceptorRegistrationConfiguration(
         FeatureFlagInterceptor featureFlagInterceptor,
         FeatureFlagProperties featureFlagProperties) {
       this.featureFlagInterceptor = featureFlagInterceptor;


### PR DESCRIPTION
## Summary

`FeatureFlagMvcInterceptorRegistrationAutoConfiguration` が `WebMvcConfigurer` を直接 `implements` していた設計を、Spring Boot の規約に従いネストした `static @Configuration` クラスに分離した。

## 変更内容

**変更前:**
```java
@AutoConfiguration(after = FeatureFlagMvcAutoConfiguration.class)
class FeatureFlagMvcInterceptorRegistrationAutoConfiguration implements WebMvcConfigurer {
    // インターセプター登録 + auto-configuration の2責務
}
```

**変更後:**
```java
@AutoConfiguration(after = FeatureFlagMvcAutoConfiguration.class)
class FeatureFlagMvcInterceptorRegistrationAutoConfiguration {
    // auto-configuration のオーケストレーションのみ

    @Configuration(proxyBeanMethods = false)
    static class MvcConfigurer implements WebMvcConfigurer {
        // WebMvcConfigurer の実装（インターセプター登録）
    }
}
```

## 設計意図

- `@AutoConfiguration` クラスは Bean 登録の制御（`after =` による依存順序）に専念
- `WebMvcConfigurer` の実装は Spring MVC の設定クラスである `@Configuration` に委譲
- Spring Boot の auto-configuration 規約に沿った責務分離

## Test plan

- [x] `./gradlew check` — Spotless + unit tests + integration tests すべて通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)