### PR TITLE
Feature: フェイルクローズドをデフォルト挙動にし feature-flags.default-enabled で設定可能に

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ This is a multi-module Gradle project (Java 25, Spring Boot 4.x) that provides f
 
 ### Extension Points
 
-- **Custom feature source**: Implement `FeatureFlagProvider` and register as a `@Bean`. The default `InMemoryFeatureFlagProvider` reads from `feature-flags.feature-names` in config. A custom bean replaces it due to `@ConditionalOnMissingBean`.
+- **Custom feature source**: Implement `FeatureFlagProvider` and register as a `@Bean`. The default `InMemoryFeatureFlagProvider` reads from `feature-flags.feature-names` in config and is **fail-closed by default** — feature names not present in the config are treated as disabled. Set `feature-flags.default-enabled: true` to switch to fail-open behavior. A custom bean replaces the default due to `@ConditionalOnMissingBean`.
 - **Custom denied response**: Define a `@ControllerAdvice` that handles `FeatureFlagAccessDeniedException`. It takes priority over the library's default handler.
 
 ### Auto-configuration Registration

--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ feature-flags:
   feature-names:
     hello-class: true
     user-find: false
+  default-enabled: false  # false (fail-closed, default) | true (fail-open)
   response:
     type: JSON  # PLAIN_TEXT | JSON | HTML (default: JSON)
 ```
+
+> **Undefined flags are blocked by default (fail-closed).** If a feature name referenced in a `@FeatureFlag` annotation is not listed under `feature-flags.feature-names`, access is denied with `403 Forbidden`. Set `feature-flags.default-enabled: true` to allow access for undefined flags instead (fail-open).
 
 Add the `@FeatureFlag` annotation to the class or method that will be the endpoint.
 
@@ -125,7 +128,10 @@ class FeatureFlagExternalDataSourceProvider implements FeatureFlagProvider {
   @Override
   public boolean isFeatureEnabled(String featureName) {
     Boolean enabled = featureManagementMapper.check(featureName);
-    if (enabled == null) return true;
+    // Choose your undefined-flag policy:
+    //   return false; — fail-closed: block access for undefined flags (recommended)
+    //   return true;  — fail-open:   allow access for undefined flags
+    if (enabled == null) return false;
     return enabled;
   }
 

--- a/core/src/main/java/net/brightroom/featureflag/core/configuration/FeatureFlagProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/configuration/FeatureFlagProperties.java
@@ -30,6 +30,7 @@ public class FeatureFlagProperties {
   private FeatureFlagPathPatterns pathPatterns = new FeatureFlagPathPatterns();
   private Map<String, Boolean> featureNames = new HashMap<>();
   private ResponseProperties response = new ResponseProperties();
+  private boolean defaultEnabled = false;
 
   /**
    * Returns the path patterns for feature flag interceptor registration.
@@ -58,6 +59,16 @@ public class FeatureFlagProperties {
     return response;
   }
 
+  /**
+   * Returns whether undefined feature flags are enabled by default.
+   *
+   * @return {@code true} if undefined flags are enabled (fail-open), {@code false} if disabled
+   *     (fail-closed)
+   */
+  public boolean defaultEnabled() {
+    return defaultEnabled;
+  }
+
   // for property binding
   void setPathPatterns(FeatureFlagPathPatterns pathPatterns) {
     this.pathPatterns = pathPatterns;
@@ -71,6 +82,11 @@ public class FeatureFlagProperties {
   // for property binding
   void setResponse(ResponseProperties response) {
     this.response = response;
+  }
+
+  // for property binding
+  void setDefaultEnabled(boolean defaultEnabled) {
+    this.defaultEnabled = defaultEnabled;
   }
 
   FeatureFlagProperties() {}

--- a/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -19,6 +19,12 @@
       "name": "feature-flags.response.type",
       "type": "net.brightroom.featureflag.core.configuration.ResponseType",
       "description": "The type of response to return."
+    },
+    {
+      "name": "feature-flags.default-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether undefined feature flags are enabled by default. Defaults to false (fail-closed): undefined flags block access. Set to true for fail-open behavior: undefined flags allow access.",
+      "defaultValue": false
     }
   ]
 }

--- a/core/src/test/java/net/brightroom/featureflag/core/configuration/FeatureFlagAutoConfigurationEmptyPropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/configuration/FeatureFlagAutoConfigurationEmptyPropertiesTest.java
@@ -28,6 +28,8 @@ class FeatureFlagAutoConfigurationEmptyPropertiesTest {
     Map<String, Boolean> featureNames = featureFlagProperties.featureNames();
     assertTrue(featureNames.isEmpty());
 
+    assertFalse(featureFlagProperties.defaultEnabled());
+
     ResponseProperties response = featureFlagProperties.response();
     assertEquals(ResponseType.JSON, response.type());
   }

--- a/core/src/test/java/net/brightroom/featureflag/core/configuration/FeatureFlagAutoConfigurationMultiplePropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/configuration/FeatureFlagAutoConfigurationMultiplePropertiesTest.java
@@ -43,6 +43,11 @@ class FeatureFlagAutoConfigurationMultiplePropertiesTest {
   }
 
   @Test
+  void shouldLoadDefaultEnabled() {
+    assertTrue(featureFlagProperties.defaultEnabled());
+  }
+
+  @Test
   void shouldLoadResponseType() {
     ResponseProperties response = featureFlagProperties.response();
     assertEquals(ResponseType.PLAIN_TEXT, response.type());

--- a/core/src/test/resources/application-multiple-properties.yaml
+++ b/core/src/test/resources/application-multiple-properties.yaml
@@ -9,5 +9,6 @@ feature-flags:
   feature-names:
     f1: true
     f2: false
+  default-enabled: true
   response:
     type: PLAIN_TEXT

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorFailClosedIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorFailClosedIntegrationTest.java
@@ -1,0 +1,51 @@
+package net.brightroom.featureflag.webmvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.brightroom.featureflag.webmvc.configuration.FeatureFlagMvcTestAutoConfiguration;
+import net.brightroom.featureflag.webmvc.endpoint.FeatureFlagUndefinedFlagController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies fail-closed behavior: when {@code feature-flags.default-enabled} is {@code false},
+ * requests to endpoints whose flag is absent from {@code feature-flags.feature-names} are blocked
+ * with {@code 403 Forbidden}.
+ */
+@WebMvcTest(
+    properties = {"feature-flags.default-enabled=false"},
+    controllers = FeatureFlagUndefinedFlagController.class)
+@Import(FeatureFlagMvcTestAutoConfiguration.class)
+class FeatureFlagInterceptorFailClosedIntegrationTest {
+
+  MockMvc mockMvc;
+
+  @Test
+  void shouldBlockAccess_whenFlagIsUndefinedInConfig_andDefaultEnabledIsFalse() throws Exception {
+    mockMvc
+        .perform(get("/undefined-flag-endpoint"))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            content()
+                .json(
+                    """
+                    {
+                      "detail"   : "Feature 'undefined-in-config-flag' is not available",
+                      "instance" : "/undefined-flag-endpoint",
+                      "status"   : 403,
+                      "title"    : "Feature flag access denied",
+                      "type"     : "https://github.com/bright-room/feature-flag-spring-boot-starter#response-types"
+                    }
+                    """));
+  }
+
+  @Autowired
+  FeatureFlagInterceptorFailClosedIntegrationTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+}

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorFailOpenIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorFailOpenIntegrationTest.java
@@ -1,0 +1,39 @@
+package net.brightroom.featureflag.webmvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.brightroom.featureflag.webmvc.configuration.FeatureFlagMvcTestAutoConfiguration;
+import net.brightroom.featureflag.webmvc.endpoint.FeatureFlagUndefinedFlagController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies fail-open behavior: when {@code feature-flags.default-enabled} is {@code true}, requests
+ * to endpoints whose flag is absent from {@code feature-flags.feature-names} are allowed through.
+ */
+@WebMvcTest(
+    properties = {"feature-flags.default-enabled=true"},
+    controllers = FeatureFlagUndefinedFlagController.class)
+@Import(FeatureFlagMvcTestAutoConfiguration.class)
+class FeatureFlagInterceptorFailOpenIntegrationTest {
+
+  MockMvc mockMvc;
+
+  @Test
+  void shouldAllowAccess_whenFlagIsUndefinedInConfig_andDefaultEnabledIsTrue() throws Exception {
+    mockMvc
+        .perform(get("/undefined-flag-endpoint"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+
+  @Autowired
+  FeatureFlagInterceptorFailOpenIntegrationTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+}

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagUndefinedFlagController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagUndefinedFlagController.java
@@ -1,0 +1,24 @@
+package net.brightroom.featureflag.webmvc.endpoint;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Test controller for verifying fail-closed / fail-open behavior.
+ *
+ * <p>The flag {@code "undefined-in-config-flag"} is intentionally absent from {@code
+ * feature-flags.feature-names} in {@code application.yaml}, so its enabled state is determined
+ * solely by {@code feature-flags.default-enabled}.
+ */
+@RestController
+public class FeatureFlagUndefinedFlagController {
+
+  @FeatureFlag("undefined-in-config-flag")
+  @GetMapping("/undefined-flag-endpoint")
+  String undefinedFlagEndpoint() {
+    return "Allowed";
+  }
+
+  public FeatureFlagUndefinedFlagController() {}
+}

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagMvcAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagMvcAutoConfiguration.java
@@ -21,7 +21,8 @@ class FeatureFlagMvcAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean(FeatureFlagProvider.class)
   FeatureFlagProvider featureFlagProvider() {
-    return new InMemoryFeatureFlagProvider(featureFlagProperties.featureNames());
+    return new InMemoryFeatureFlagProvider(
+        featureFlagProperties.featureNames(), featureFlagProperties.defaultEnabled());
   }
 
   @Bean

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/provider/FeatureFlagProvider.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/provider/FeatureFlagProvider.java
@@ -7,11 +7,20 @@ package net.brightroom.featureflag.webmvc.provider;
  * are stored and accessed, enabling a consistent method for determining whether a specific feature
  * is enabled or disabled at runtime. This can be used to control feature rollout, perform
  * experiments, or toggle functionality dynamically.
+ *
+ * <p><b>Undefined flag policy:</b> Implementations must decide what to return when {@code
+ * featureName} is not known to the provider. The built-in {@link InMemoryFeatureFlagProvider} uses
+ * a <em>fail-closed</em> policy by default (returns {@code false} for unknown flags), which can be
+ * changed to fail-open via {@code feature-flags.default-enabled: true}. Custom implementations
+ * should document their own policy clearly.
  */
 public interface FeatureFlagProvider {
 
   /**
    * Determines whether a specific feature is enabled based on its feature flag.
+   *
+   * <p>The return value for a feature name that is not managed by this provider is
+   * implementation-defined. See the implementing class for its undefined-flag policy.
    *
    * @param featureName the name of the feature whose status is to be verified
    * @return {@code true} if the feature is enabled, {@code false} otherwise

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/provider/InMemoryFeatureFlagProvider.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/provider/InMemoryFeatureFlagProvider.java
@@ -14,34 +14,40 @@ import java.util.Map;
 public class InMemoryFeatureFlagProvider implements FeatureFlagProvider {
 
   private final Map<String, Boolean> features;
+  private final boolean defaultEnabled;
 
   /**
    * Returns whether the specified feature is enabled.
    *
-   * <p><b>Fail-open behavior:</b> If {@code featureName} is not present in the feature map, this
-   * method returns {@code true} (enabled) by default. This means that a feature flag referenced in
-   * a {@code @FeatureFlag} annotation but missing from the configuration will allow access rather
-   * than blocking it. Ensure that all feature flag names used in {@code @FeatureFlag} annotations
-   * are explicitly configured to avoid unintended access.
+   * <p><b>Fail-closed behavior (default):</b> If {@code featureName} is not present in the feature
+   * map, this method returns the value of {@code defaultEnabled} (defaults to {@code false}). With
+   * the default configuration, a feature flag referenced in a {@code @FeatureFlag} annotation but
+   * missing from the configuration will block access. Set {@code feature-flags.default-enabled:
+   * true} in your configuration for fail-open behavior.
    *
    * @param featureName the name of the feature flag to check
-   * @return {@code true} if the feature is enabled or not configured, {@code false} if explicitly
-   *     disabled
+   * @return {@code true} if the feature is explicitly enabled, {@code false} if explicitly disabled
+   *     or not configured (with default fail-closed behavior)
    */
   @Override
   public boolean isFeatureEnabled(String featureName) {
-    return features.getOrDefault(featureName, true);
+    return features.getOrDefault(featureName, defaultEnabled);
   }
 
   /**
-   * Constructs an instance of {@code InMemoryFeatureFlagProvider} with the provided feature flags.
+   * Constructs an instance of {@code InMemoryFeatureFlagProvider} with the provided feature flags
+   * and default enabled status.
    *
    * @param features a map containing feature flag names as keys and their activation status
    *     (enabled or disabled) as values. Feature names are represented as strings, and their
    *     corresponding statuses are represented as booleans, where {@code true} indicates that the
    *     feature is enabled, and {@code false} indicates that the feature is disabled.
+   * @param defaultEnabled the default enabled status for features not present in the map. Use
+   *     {@code false} for fail-closed behavior (blocks access for undefined flags) or {@code true}
+   *     for fail-open behavior (allows access for undefined flags).
    */
-  public InMemoryFeatureFlagProvider(Map<String, Boolean> features) {
+  public InMemoryFeatureFlagProvider(Map<String, Boolean> features, boolean defaultEnabled) {
     this.features = Map.copyOf(features);
+    this.defaultEnabled = defaultEnabled;
   }
 }

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/provider/InMemoryFeatureFlagProviderDefaultEnabledTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/provider/InMemoryFeatureFlagProviderDefaultEnabledTest.java
@@ -1,0 +1,40 @@
+package net.brightroom.featureflag.webmvc.provider;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InMemoryFeatureFlagProviderDefaultEnabledTest {
+
+  @Test
+  void isFeatureEnabled_returnsFalse_whenFlagIsUndefined_andDefaultEnabledIsFalse() {
+    var provider = new InMemoryFeatureFlagProvider(Map.of("flag-a", true), false);
+    assertFalse(provider.isFeatureEnabled("undefined-flag"));
+  }
+
+  @Test
+  void isFeatureEnabled_returnsTrue_whenFlagIsUndefined_andDefaultEnabledIsTrue() {
+    var provider = new InMemoryFeatureFlagProvider(Map.of("flag-a", true), true);
+    assertTrue(provider.isFeatureEnabled("undefined-flag"));
+  }
+
+  @Test
+  void isFeatureEnabled_returnsTrue_whenFlagIsExplicitlyEnabled_regardlessOfDefaultEnabled() {
+    var providerFailClosed = new InMemoryFeatureFlagProvider(Map.of("flag-a", true), false);
+    var providerFailOpen = new InMemoryFeatureFlagProvider(Map.of("flag-a", true), true);
+
+    assertTrue(providerFailClosed.isFeatureEnabled("flag-a"));
+    assertTrue(providerFailOpen.isFeatureEnabled("flag-a"));
+  }
+
+  @Test
+  void isFeatureEnabled_returnsFalse_whenFlagIsExplicitlyDisabled_regardlessOfDefaultEnabled() {
+    var providerFailClosed = new InMemoryFeatureFlagProvider(Map.of("flag-a", false), false);
+    var providerFailOpen = new InMemoryFeatureFlagProvider(Map.of("flag-a", false), true);
+
+    assertFalse(providerFailClosed.isFeatureEnabled("flag-a"));
+    assertFalse(providerFailOpen.isFeatureEnabled("flag-a"));
+  }
+}

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/provider/InMemoryFeatureFlagProviderTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/provider/InMemoryFeatureFlagProviderTest.java
@@ -13,8 +13,8 @@ class InMemoryFeatureFlagProviderTest {
   FeatureFlagProvider featureFlagProvider;
 
   @Test
-  void undefinedFeaturesAreNotManagedByFeatureFlag() {
-    assertTrue(featureFlagProvider.isFeatureEnabled("undefined-api"));
+  void undefinedFeaturesAreDisabledByDefault() {
+    assertFalse(featureFlagProvider.isFeatureEnabled("undefined-api"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `InMemoryFeatureFlagProvider` のデフォルト挙動を **fail-open → fail-closed** に変更（`getOrDefault(name, true)` → `getOrDefault(name, defaultEnabled)`）
- `feature-flags.default-enabled` プロパティ（デフォルト `false`）で fail-open / fail-closed を切り替え可能にした
- `FeatureFlagProperties` に `defaultEnabled` フィールド・アクセサ・セッターを追加
- `additional-spring-configuration-metadata.json` に `feature-flags.default-enabled` のメタデータを追加
- `FeatureFlagProvider` / `InMemoryFeatureFlagProvider` の Javadoc を更新
- `README.md` / `CLAUDE.md` にフェイルクローズドがデフォルトである旨と設定方法を追記

## Test plan

- [x] `InMemoryFeatureFlagProviderDefaultEnabledTest` — `defaultEnabled=false/true` の直接ユニットテスト（Spring なし）
- [x] `InMemoryFeatureFlagProviderTest` — `undefinedFeaturesAreDisabledByDefault` をフェイルクローズドに合わせて更新
- [x] `FeatureFlagAutoConfigurationEmptyPropertiesTest` — `defaultEnabled()` のデフォルト `false` を確認
- [x] `FeatureFlagAutoConfigurationMultiplePropertiesTest` — `default-enabled: true` のプロパティバインディングを確認
- [x] `FeatureFlagInterceptorFailClosedIntegrationTest` — `default-enabled=false` 時に未定義フラグが 403 になることを E2E で確認
- [x] `FeatureFlagInterceptorFailOpenIntegrationTest` — `default-enabled=true` 時に未定義フラグが 200 になることを E2E で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)