### PR TITLE
Fix: メソッド @ FeatureFlag がクラス @ FeatureFlag を上書きしない問題を修正

### DIFF
--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagClassMethodPriorityController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagClassMethodPriorityController.java
@@ -1,0 +1,23 @@
+package net.brightroom.featureflag.webmvc.endpoint;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/legacy")
+@FeatureFlag("legacy-api")
+public class FeatureFlagClassMethodPriorityController {
+
+  @GetMapping("/data")
+  public String data() {
+    return "Legacy data";
+  }
+
+  @FeatureFlag("special-endpoint")
+  @GetMapping("/special")
+  public String special() {
+    return "Special endpoint data";
+  }
+}

--- a/webmvc/src/integrationTest/resources/application.yaml
+++ b/webmvc/src/integrationTest/resources/application.yaml
@@ -7,5 +7,7 @@ feature-flags:
     development-stage-endpoint: false
     enable-class-level-feature: true
     disable-class-level-feature: false
+    legacy-api: false
+    special-endpoint: true
   response:
     type: json

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptor.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/configuration/FeatureFlagInterceptor.java
@@ -23,9 +23,12 @@ class FeatureFlagInterceptor implements HandlerInterceptor {
     }
 
     FeatureFlag methodAnnotation = handlerMethod.getMethodAnnotation(FeatureFlag.class);
-    validateAnnotation(methodAnnotation);
-    if (checkFeatureFlag(methodAnnotation)) {
-      throw new FeatureFlagAccessDeniedException(methodAnnotation.value());
+    if (methodAnnotation != null) {
+      validateAnnotation(methodAnnotation);
+      if (checkFeatureFlag(methodAnnotation)) {
+        throw new FeatureFlagAccessDeniedException(methodAnnotation.value());
+      }
+      return true;
     }
 
     FeatureFlag classAnnotation = handlerMethod.getBeanType().getAnnotation(FeatureFlag.class);


### PR DESCRIPTION
## Summary

- クラスとメソッドの両方に `@FeatureFlag` が付いている場合、メソッドのアノテーションが優先されるべきだが、従来実装ではメソッドが有効でもクラスアノテーションのチェックが続行されていた
- `FeatureFlagInterceptor` でメソッドにアノテーションが存在する場合はクラスアノテーションを評価せず early return するよう修正
- バグを再現する統合テスト（`FeatureFlagClassMethodPriorityController` + テストケース2件）を追加してから修正

## Test plan

- [x] `shouldBlockAccess_whenClassLevelFeatureIsDisabledAndNoMethodAnnotation` — メソッドアノテーションなし、クラスOFF → 403
- [x] `shouldAllowAccess_whenMethodAnnotationOverridesDisabledClassAnnotation` — メソッドにON、クラスにOFF → 200（メソッド優先）
- [x] `./gradlew :webmvc:check` が全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)