### PR TITLE
Close #132: Add real-server integration tests using @SpringBootTest(RANDOM_PORT)

### DIFF
--- a/webmvc/build.gradle.kts
+++ b/webmvc/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation(libs.spring.boot.starter.webmvc.test)
 
+    integrationTestImplementation(libs.spring.boot.starter.test)
     integrationTestImplementation(libs.spring.boot.starter.thymeleaf)
     integrationTestImplementation(libs.jsoup)
 }

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorRealServerCustomHandlerIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorRealServerCustomHandlerIntegrationTest.java
@@ -1,0 +1,62 @@
+package net.brightroom.featureflag.webmvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.webmvc.endpoint.FeatureFlagDisableController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = FeatureFlagInterceptorRealServerCustomHandlerIntegrationTest.TestConfig.class)
+class FeatureFlagInterceptorRealServerCustomHandlerIntegrationTest {
+
+  @Configuration
+  @EnableAutoConfiguration
+  @Import({
+    FeatureFlagDisableController.class,
+    FeatureFlagInterceptorRealServerCustomHandlerIntegrationTest.CustomExceptionHandler.class
+  })
+  static class TestConfig {}
+
+  @ControllerAdvice
+  @Order(0)
+  static class CustomExceptionHandler {
+
+    @ExceptionHandler(FeatureFlagAccessDeniedException.class)
+    ResponseEntity<String> handle(FeatureFlagAccessDeniedException e) {
+      return ResponseEntity.status(503).body("custom: " + e.featureName());
+    }
+  }
+
+  @Value("${local.server.port}")
+  int port;
+
+  @Test
+  void customHandlerTakesPriority_whenFeatureIsDisabled() throws Exception {
+    HttpResponse<String> response =
+        HttpClient.newHttpClient()
+            .send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + port + "/test/disable"))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(503, response.statusCode());
+    assertEquals("custom: disable-class-level-feature", response.body());
+  }
+}

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorRealServerIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorRealServerIntegrationTest.java
@@ -1,0 +1,61 @@
+package net.brightroom.featureflag.webmvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import net.brightroom.featureflag.webmvc.endpoint.FeatureFlagMethodLevelController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = FeatureFlagInterceptorRealServerIntegrationTest.TestConfig.class)
+class FeatureFlagInterceptorRealServerIntegrationTest {
+
+  @Configuration
+  @EnableAutoConfiguration
+  @Import(FeatureFlagMethodLevelController.class)
+  static class TestConfig {}
+
+  @Value("${local.server.port}")
+  int port;
+
+  @Test
+  void shouldAllowAccess_whenFeatureIsEnabled() throws Exception {
+    HttpResponse<String> response =
+        HttpClient.newHttpClient()
+            .send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + port + "/experimental-stage-endpoint"))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(200, response.statusCode());
+    assertEquals("Allowed", response.body());
+  }
+
+  @Test
+  void shouldBlockAccess_whenFeatureIsDisabled() throws Exception {
+    HttpResponse<String> response =
+        HttpClient.newHttpClient()
+            .send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create("http://localhost:" + port + "/development-stage-endpoint"))
+                    .GET()
+                    .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+    assertEquals(403, response.statusCode());
+    assertTrue(response.body().contains("Feature 'development-stage-endpoint' is not available"));
+    assertTrue(response.body().contains("Feature flag access denied"));
+  }
+}


### PR DESCRIPTION
Add two new integration test classes for the webmvc module that use @SpringBootTest(webEnvironment = RANDOM_PORT) to spin up an actual embedded Tomcat server and verify behavior via real HTTP requests (java.net.http.HttpClient):

- FeatureFlagInterceptorRealServerIntegrationTest: verifies access is allowed when a feature is enabled (200) and blocked when disabled (403)
- FeatureFlagInterceptorRealServerCustomHandlerIntegrationTest: verifies that a custom @ControllerAdvice takes priority over the library default

Each test class declares a minimal @Configuration/@EnableAutoConfiguration inner class with only the required controllers imported, avoiding duplicate URL mapping conflicts that arise when all test controllers (REST + view) are loaded together.

Also adds spring-boot-starter-test to integrationTestImplementation for a complete test utility set.