### PR TITLE
Automate Maven Central release via GitHub Release event

### DIFF
--- a/.github/workflows/on-deploy.yaml
+++ b/.github/workflows/on-deploy.yaml
@@ -1,9 +1,8 @@
 name: on-deploy
 
 on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 
 jobs:
   publish-artifacts:
@@ -13,6 +12,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Gradle Cache
         uses: ./.github/actions/gradle-cache
@@ -25,16 +26,4 @@ jobs:
           PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
           PGP_SIGNING_KEY_PASSPHRASE: ${{ secrets.PGP_SIGNING_KEY_PASSPHRASE }}
         with:
-          command: sonatypeCentralUpload
-
-  generate-release-note:
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    needs:
-      - publish-artifacts
-
-    steps:
-      - name: Generate a release note
-        run: gh release create ${{ github.ref_name }} --generate-notes --latest --verify-tag --repo ${{ github.repository }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          command: sonatypeCentralUpload -PreleaseVersion=${{ github.event.release.tag_name }}

--- a/gradle-scripts/src/main/kotlin/spring-boot-starter.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/spring-boot-starter.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "net.bright-room.feature-flag-spring-boot-starter"
-version = libs.versions.app.get()
+version = providers.gradleProperty("releaseVersion").getOrElse("0.0.0-SNAPSHOT")
 
 dependencies {
     annotationProcessor(libs.spring.boot.configuration.processor)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-app = "3.0.1"
 java = "25"
 
 [libraries]


### PR DESCRIPTION
## Summary

- `on-deploy.yaml` のトリガーを `push: tags` から `release: published` に変更
- リリースのタグ名から `-PreleaseVersion=X.Y.Z` としてGradleにバージョンを渡す
- `generate-release-note` ジョブを削除（GitHub Release はユーザーが作成済みのため不要）
- `gradle/libs.versions.toml` から `app` バージョンを削除
- `spring-boot-starter.gradle.kts` のバージョン解決を `releaseVersion` Gradleプロパティに変更（デフォルト: `0.0.0-SNAPSHOT`）

## New release flow

1. GitHub の Releases ページで **「Draft a new release」** をクリック
2. タグ名にバージョン番号を入力（例: `3.1.0`）、ターゲットは `main`
3. 「Generate release notes」でリリースノートを自動生成
4. **「Publish release」** をクリック
5. → CI が自動で Maven Central に公開

## Test plan

- [x] `on-deploy.yaml` のトリガーが `release: published` になっていることを確認
- [x] `libs.versions.toml` から `app` バージョンが削除されていることを確認
- [x] `spring-boot-starter.gradle.kts` が `releaseVersion` プロパティを参照していることを確認
- [x] `./gradlew build` がローカルで成功することを確認（`0.0.0-SNAPSHOT` として動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)