### PR TITLE
fix: Claudeコードレビューの指摘事項を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,13 +29,15 @@ Code formatting uses Google Java Format via Spotless. Always run `spotlessApply`
 
 ## Architecture
 
-This is a multi-module Gradle project (Java 25, Spring Boot 4.x) that provides feature flag support for Spring MVC applications. It is published to Maven Central under group `net.bright-room.feature-flag-spring-boot-starter`.
+This is a multi-module Gradle project (Java 25, Spring Boot 4.x) that provides feature flag support for Spring MVC and Spring WebFlux applications. It is published to Maven Central under group `net.bright-room.feature-flag-spring-boot-starter`.
 
 ### Modules
 
-- **`core`** — Annotation and configuration properties. Contains `@FeatureFlag` annotation and `FeatureFlagProperties` (`feature-flags.*` config prefix). `FeatureFlagAutoConfiguration` bootstraps property binding.
-- **`webmvc`** — Spring MVC interceptor implementation. Depends on `core`.
-- **`gradle-scripts`** — Composite build providing convention plugins: `spring-boot-starter`, `publish-plugin`, `spotless-java`, `spotless-kotlin`.
+- **`core`** — Annotation, configuration properties, provider SPI, and shared resolution logic. Contains `@FeatureFlag` annotation, `FeatureFlagProperties` (`feature-flags.*` config prefix), `FeatureFlagProvider`/`MutableFeatureFlagProvider` SPI, and `ProblemDetailBuilder`/`HtmlResponseBuilder`. `FeatureFlagAutoConfiguration` bootstraps property binding only (no provider beans).
+- **`webmvc`** — Spring MVC interceptor implementation. Depends on `core`. Registers `InMemoryFeatureFlagProvider` bean via `FeatureFlagMvcAutoConfiguration`.
+- **`webflux`** — Spring WebFlux AOP + HandlerFilterFunction implementation. Depends on `core`. Uses `ReactiveFeatureFlagProvider` and `FeatureFlagAspect` for annotation-based controllers, `FeatureFlagHandlerFilterFunction` for functional endpoints.
+- **`actuator`** — Runtime feature flag management via Spring Boot Actuator endpoint (`/actuator/feature-flags`). Registers `MutableInMemoryFeatureFlagProvider` bean and publishes `FeatureFlagChangedEvent` on flag changes. Auto-configured before webmvc/webflux.
+- **`gradle-scripts`** — Composite build providing convention plugins: `spring-boot-starter`, `publish-plugin`, `spotless-java`, `spotless-kotlin`, `integration-test`.
 
 ### Request Flow
 
@@ -48,13 +50,16 @@ This is a multi-module Gradle project (Java 25, Spring Boot 4.x) that provides f
 
 - **Custom feature source**: Implement `FeatureFlagProvider` and register as a `@Bean`. The default `InMemoryFeatureFlagProvider` reads from `feature-flags.feature-names` in config and is **fail-closed by default** — feature names not present in the config are treated as disabled. Set `feature-flags.default-enabled: true` to switch to fail-open behavior. A custom bean replaces the default due to `@ConditionalOnMissingBean`.
 - **Custom denied response**: Define a `@ControllerAdvice` that handles `FeatureFlagAccessDeniedException`. It takes priority over the library's default handler.
+- **Gradual rollout**: Use `@FeatureFlag(value = "name", rollout = 50)` to enable a feature for a percentage of requests. Implement `FeatureFlagContextResolver` (webmvc) or `ReactiveFeatureFlagContextResolver` (webflux) for sticky rollout. Implement `RolloutStrategy` (webmvc) or `ReactiveRolloutStrategy` (webflux) to customize bucketing.
 
 ### Auto-configuration Registration
 
-Both modules use Spring Boot's `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` to register their `@AutoConfiguration` classes. Auto-configuration ordering is enforced with `after =` references:
+All modules use Spring Boot's `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` to register their `@AutoConfiguration` classes. Auto-configuration ordering is enforced with `after =` / `beforeName =` references:
 1. `FeatureFlagAutoConfiguration` (core)
-2. `FeatureFlagMvcAutoConfiguration` (webmvc)
-3. `FeatureFlagMvcInterceptorRegistrationAutoConfiguration` (webmvc)
+2. `FeatureFlagActuatorAutoConfiguration` (actuator) — before webmvc/webflux
+3. `FeatureFlagMvcAutoConfiguration` (webmvc)
+4. `FeatureFlagMvcInterceptorRegistrationAutoConfiguration` (webmvc)
+5. `FeatureFlagWebFluxAutoConfiguration` (webflux)
 
 ### Response Types
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ See the [release notes](https://github.com/bright-room/feature-flag-spring-boot-
         <artifactId>webflux</artifactId>
         <version>${version}</version>
     </dependency>
+
+    <!-- Runtime flag management via Actuator (optional) -->
+    <dependency>
+        <groupId>net.bright-room.feature-flag-spring-boot-starter</groupId>
+        <artifactId>actuator</artifactId>
+        <version>${version}</version>
+    </dependency>
 </dependencies>
 ```
 
@@ -41,12 +48,15 @@ See the [release notes](https://github.com/bright-room/feature-flag-spring-boot-
 ```groovy
 dependencies {
     implementation 'net.bright-room.feature-flag-spring-boot-starter:core:${version}'
-    
+
     // Using Spring boot starter webmvc
     implementation 'net.bright-room.feature-flag-spring-boot-starter:webmvc:${version}'
 
     // Using Spring boot starter webflux
     implementation 'net.bright-room.feature-flag-spring-boot-starter:webflux:${version}'
+
+    // Runtime flag management via Actuator (optional)
+    implementation 'net.bright-room.feature-flag-spring-boot-starter:actuator:${version}'
 }
 ```
 
@@ -54,12 +64,15 @@ dependencies {
 ```kotlin
 dependencies {
     implementation("net.bright-room.feature-flag-spring-boot-starter:core:${version}")
-    
+
     // Using Spring boot starter webmvc
     implementation("net.bright-room.feature-flag-spring-boot-starter:webmvc:${version}")
 
     // Using Spring boot starter webflux
     implementation("net.bright-room.feature-flag-spring-boot-starter:webflux:${version}")
+
+    // Runtime flag management via Actuator (optional)
+    implementation("net.bright-room.feature-flag-spring-boot-starter:actuator:${version}")
 }
 ```
 
@@ -263,7 +276,7 @@ Define an `AccessDeniedHandlerFilterResolution` bean to customize the response r
 
 ```java
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
-import net.brightroom.featureflag.webflux.configuration.AccessDeniedHandlerFilterResolution;
+import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
@@ -279,6 +292,165 @@ public class CustomHandlerFilterResolutionConfig {
     return (request, e) -> ServerResponse.status(HttpStatus.FORBIDDEN)
         .contentType(MediaType.TEXT_PLAIN)
         .bodyValue("Feature '" + e.featureName() + "' is disabled.");
+  }
+}
+```
+
+## Gradual Rollout
+
+Use the `rollout` attribute on `@FeatureFlag` to enable a feature for only a percentage of requests.
+
+```java
+@RestController
+class BetaController {
+
+  @GetMapping("/new-feature")
+  @FeatureFlag(value = "new-feature", rollout = 50) // enable for 50% of requests
+  String newFeature() {
+    return "You're in the rollout!";
+  }
+}
+```
+
+By default, rollout is **non-sticky** — each request is evaluated independently using a random identifier. This means the same user may see different behavior across requests.
+
+### Sticky Rollout
+
+To make rollout sticky (the same user always gets the same result), implement `FeatureFlagContextResolver` (Spring MVC) or `ReactiveFeatureFlagContextResolver` (Spring WebFlux) and register it as a `@Bean`.
+
+```java
+// Spring MVC
+@Component
+class UserBasedContextResolver implements FeatureFlagContextResolver {
+
+  @Override
+  public Optional<FeatureFlagContext> resolve(HttpServletRequest request) {
+    String userId = request.getHeader("X-User-Id");
+    if (userId == null) return Optional.empty(); // fail-open: skip rollout check
+    return Optional.of(new FeatureFlagContext(userId));
+  }
+}
+```
+
+```java
+// Spring WebFlux
+@Component
+class UserBasedReactiveContextResolver implements ReactiveFeatureFlagContextResolver {
+
+  @Override
+  public Mono<FeatureFlagContext> resolve(ServerHttpRequest request) {
+    String userId = request.getHeaders().getFirst("X-User-Id");
+    if (userId == null) return Mono.empty(); // fail-open: skip rollout check
+    return Mono.just(new FeatureFlagContext(userId));
+  }
+}
+```
+
+When the context resolver returns empty, the rollout check is skipped and the feature is treated as fully enabled (fail-open).
+
+### Custom Rollout Strategy
+
+To change how the rollout bucketing works, implement `RolloutStrategy` (Spring MVC) or `ReactiveRolloutStrategy` (Spring WebFlux) and register it as a `@Bean`.
+
+### WebFlux Functional Endpoints
+
+For functional endpoints, use `FeatureFlagHandlerFilterFunction.of(name, rollout)`:
+
+```java
+@Bean
+RouterFunction<ServerResponse> routes(FeatureFlagHandlerFilterFunction featureFlagFilter) {
+    return route()
+        .GET("/new-feature", handler::handle)
+        .filter(featureFlagFilter.of("new-feature", 50))
+        .build();
+}
+```
+
+## Runtime Flag Management (Actuator)
+
+The `actuator` module provides a Spring Boot Actuator endpoint for reading and updating feature flags at runtime without restarting the application.
+
+### Setup
+
+1. Add the `actuator` dependency (see [Installation](#installation)).
+2. Expose the endpoint:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: feature-flags
+```
+
+### Read all flags
+
+```
+GET /actuator/feature-flags
+```
+
+Response:
+
+```json
+{
+  "features": {
+    "hello-class": true,
+    "user-find": false
+  },
+  "defaultEnabled": false
+}
+```
+
+### Update a flag
+
+```
+POST /actuator/feature-flags
+Content-Type: application/json
+
+{
+  "featureName": "user-find",
+  "enabled": true
+}
+```
+
+Response:
+
+```json
+{
+  "features": {
+    "hello-class": true,
+    "user-find": true
+  },
+  "defaultEnabled": false
+}
+```
+
+If the flag does not exist, it is created with the given state.
+
+### Restricting access
+
+By default, both read and write operations are unrestricted. In production, consider restricting access:
+
+```yaml
+management:
+  endpoint:
+    feature-flags:
+      access: READ_ONLY
+```
+
+Or secure the endpoint with Spring Security.
+
+### Event integration
+
+A `FeatureFlagChangedEvent` is published every time a flag is updated via the actuator endpoint. Subscribe with `@EventListener` to react to changes (e.g., clearing caches, logging audit trails).
+
+```java
+@Component
+class FeatureFlagChangeListener {
+
+  @EventListener
+  void onFlagChanged(FeatureFlagChangedEvent event) {
+    log.info("Flag '{}' changed to {}", event.featureName(), event.enabled());
   }
 }
 ```

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
@@ -52,6 +52,9 @@ public class FeatureFlagEndpoint {
    */
   @WriteOperation
   public FeatureFlagEndpointResponse updateFeature(String featureName, boolean enabled) {
+    if (featureName == null || featureName.isBlank()) {
+      throw new IllegalArgumentException("featureName must not be null or blank");
+    }
     provider.setFeatureEnabled(featureName, enabled);
     eventPublisher.publishEvent(new FeatureFlagChangedEvent(this, featureName, enabled));
     return new FeatureFlagEndpointResponse(provider.getFeatures(), defaultEnabled);

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.actuator.endpoint;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,5 +91,35 @@ class FeatureFlagEndpointTest {
     assertEquals(2, keys.size());
     assertFalse(response.features().get("feature-a"));
     assertTrue(response.features().get("feature-b"));
+  }
+
+  @Test
+  void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsNull() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
+    var endpoint = new FeatureFlagEndpoint(provider, false, eventPublisher);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> endpoint.updateFeature(null, true))
+        .withMessageContaining("featureName must not be null or blank");
+  }
+
+  @Test
+  void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsEmpty() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
+    var endpoint = new FeatureFlagEndpoint(provider, false, eventPublisher);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> endpoint.updateFeature("", true))
+        .withMessageContaining("featureName must not be null or blank");
+  }
+
+  @Test
+  void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsBlank() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
+    var endpoint = new FeatureFlagEndpoint(provider, false, eventPublisher);
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> endpoint.updateFeature("   ", true))
+        .withMessageContaining("featureName must not be null or blank");
   }
 }

--- a/core/src/test/java/net/brightroom/featureflag/core/autoconfigure/FeatureFlagAutoConfigurationEmptyPropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/autoconfigure/FeatureFlagAutoConfigurationEmptyPropertiesTest.java
@@ -19,6 +19,7 @@ class FeatureFlagAutoConfigurationEmptyPropertiesTest {
 
   FeatureFlagProperties featureFlagProperties;
 
+  @SuppressWarnings("deprecation")
   @Test
   void shouldBeEmptyWhenPropertiesAreNotProvided() {
     FeatureFlagPathPatterns pathPatterns = featureFlagProperties.pathPatterns();

--- a/core/src/test/java/net/brightroom/featureflag/core/autoconfigure/FeatureFlagAutoConfigurationMultiplePropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/autoconfigure/FeatureFlagAutoConfigurationMultiplePropertiesTest.java
@@ -21,6 +21,7 @@ class FeatureFlagAutoConfigurationMultiplePropertiesTest {
 
   FeatureFlagProperties featureFlagProperties;
 
+  @SuppressWarnings("deprecation")
   @Test
   void shouldLoadMultipleIncludePathPatterns() {
     List<String> pathPattern = featureFlagProperties.pathPatterns().includes();
@@ -29,6 +30,7 @@ class FeatureFlagAutoConfigurationMultiplePropertiesTest {
     assertTrue(pathPattern.contains("/web/**"));
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   void shouldLoadMultipleExcludePathPatterns() {
     List<String> pathPattern = featureFlagProperties.pathPatterns().excludes();

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
@@ -49,6 +49,16 @@ class FeatureFlagInterceptorTest {
   // --- validateAnnotation ---
 
   @Test
+  void preHandle_throwsIllegalStateException_whenFeatureFlagValueIsEmpty() {
+    FeatureFlag annotation = featureFlagAnnotation("", 100);
+    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
+
+    assertThatIllegalStateException()
+        .isThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+        .withMessageContaining("non-empty value");
+  }
+
+  @Test
   void preHandle_throwsIllegalStateException_whenRolloutIsNegative() {
     FeatureFlag annotation = featureFlagAnnotation("my-feature", -1);
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);


### PR DESCRIPTION
## Summary

- **M-1 (プロダクトコード)**: `FeatureFlagEndpoint.updateFeature()` に `featureName` の null/blank バリデーションを追加
- **M-1 (テストコード)**: `FeatureFlagInterceptorTest` に空文字 `@FeatureFlag` バリデーションのユニットテストを追加
- **H-1 (ドキュメント)**: README に actuator モジュール（Runtime Flag Management）セクションを追加
- **H-2 (ドキュメント)**: README に Gradual Rollout セクションを追加
- **H-3 (ドキュメント)**: README の WebFlux `AccessDeniedHandlerFilterResolution` インポートパスを修正
- **L-1 (テストコード)**: deprecated `pathPatterns()` 呼び出しに `@SuppressWarnings("deprecation")` を追加
- **L-2 (ドキュメント)**: CLAUDE.md のモジュール説明・auto-configuration 順序を現状に合わせて更新

## Test plan

- [x] `./gradlew check` が全モジュールでパスすることを確認済み
- [ ] README の actuator セクションのリクエスト/レスポンス例が正確であることを確認
- [ ] README の Gradual Rollout セクションのコード例がコンパイル可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)