### PR TITLE
Close #181: docs: update README config and actuator response examples to new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,18 @@ By default, it is available by defining the functions you want to manage in the 
 
 ```yaml
 feature-flags:
-  feature-names:
-    hello-class: true
-    user-find: false
+  features:
+    hello-class:
+      enabled: true
+    user-find:
+      enabled: false
+      rollout: 50
   default-enabled: false  # false (fail-closed, default) | true (fail-open)
   response:
     type: JSON  # PLAIN_TEXT | JSON | HTML (default: JSON)
 ```
 
-> **Undefined flags are blocked by default (fail-closed).** If a feature name referenced in a `@FeatureFlag` annotation is not listed under `feature-flags.feature-names`, access is denied with `403 Forbidden`. Set `feature-flags.default-enabled: true` to allow access for undefined flags instead (fail-open).
+> **Undefined flags are blocked by default (fail-closed).** If a feature name referenced in a `@FeatureFlag` annotation is not listed under `feature-flags.features`, access is denied with `403 Forbidden`. Set `feature-flags.default-enabled: true` to allow access for undefined flags instead (fail-open).
 
 Add the `@FeatureFlag` annotation to the class or method that will be the endpoint.
 
@@ -419,10 +422,10 @@ Response:
 
 ```json
 {
-  "features": {
-    "hello-class": true,
-    "user-find": false
-  },
+  "features": [
+    { "featureName": "hello-class", "enabled": true, "rollout": 100 },
+    { "featureName": "user-find", "enabled": false, "rollout": 50 }
+  ],
   "defaultEnabled": false
 }
 ```
@@ -443,10 +446,10 @@ Response:
 
 ```json
 {
-  "features": {
-    "hello-class": true,
-    "user-find": true
-  },
+  "features": [
+    { "featureName": "hello-class", "enabled": true, "rollout": 100 },
+    { "featureName": "user-find", "enabled": true, "rollout": 50 }
+  ],
   "defaultEnabled": false
 }
 ```


### PR DESCRIPTION
README.md の設定例と Actuator レスポンス例を新形式に更新。

- `feature-names` フラット Map 設定を `features` ネスト構造に更新
- Actuator レスポンス例を `Map<String, Boolean>` から `List<{featureName, enabled, rollout}>` 形式に更新

Closes #181

Generated with [Claude Code](https://claude.ai/code)