### PR TITLE
Close #190: fix: add missing Javadoc comments to actuator constructors

### DIFF
--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
@@ -52,6 +52,9 @@ import org.springframework.context.annotation.Configuration;
     })
 public class FeatureFlagActuatorAutoConfiguration {
 
+  /** Creates a new {@link FeatureFlagActuatorAutoConfiguration}. */
+  FeatureFlagActuatorAutoConfiguration() {}
+
   @Configuration(proxyBeanMethods = false)
   @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
   static class ServletConfiguration {

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicator.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicator.java
@@ -37,6 +37,12 @@ public class FeatureFlagHealthIndicator extends AbstractHealthIndicator {
   private final FeatureFlagProvider provider;
   private final FeatureFlagProperties properties;
 
+  /**
+   * Creates a new {@link FeatureFlagHealthIndicator}.
+   *
+   * @param provider the feature flag provider to check
+   * @param properties the feature flag configuration properties
+   */
   public FeatureFlagHealthIndicator(
       FeatureFlagProvider provider, FeatureFlagProperties properties) {
     super("Feature flag health check failed");

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicator.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicator.java
@@ -38,6 +38,12 @@ public class ReactiveFeatureFlagHealthIndicator extends AbstractReactiveHealthIn
   private final ReactiveFeatureFlagProvider provider;
   private final FeatureFlagProperties properties;
 
+  /**
+   * Creates a new {@link ReactiveFeatureFlagHealthIndicator}.
+   *
+   * @param provider the reactive feature flag provider to check
+   * @param properties the feature flag configuration properties
+   */
   public ReactiveFeatureFlagHealthIndicator(
       ReactiveFeatureFlagProvider provider, FeatureFlagProperties properties) {
     super("Feature flag health check failed");


### PR DESCRIPTION
Close #190

## Summary

- Add explicit package-private constructor with Javadoc to `FeatureFlagActuatorAutoConfiguration`
- Add Javadoc to `FeatureFlagHealthIndicator` constructor
- Add Javadoc to `ReactiveFeatureFlagHealthIndicator` constructor

Generated with [Claude Code](https://claude.ai/code)