### PR TITLE
Close #189: Add missing Javadoc to core module fields and constructors

### DIFF
--- a/core/src/main/java/net/brightroom/featureflag/core/context/FeatureFlagContext.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/context/FeatureFlagContext.java
@@ -9,8 +9,16 @@ import java.util.Objects;
  * For non-sticky (per-request random) rollout, implementations may pass a random UUID. For sticky
  * rollout (same user always gets the same result), pass a stable identifier such as a user ID or
  * session ID.
+ *
+ * @param userIdentifier a non-blank identifier used to bucket requests into rollout groups
  */
 public record FeatureFlagContext(String userIdentifier) {
+  /**
+   * Validates that {@code userIdentifier} is not null or blank.
+   *
+   * @throws NullPointerException if {@code userIdentifier} is null
+   * @throws IllegalArgumentException if {@code userIdentifier} is blank
+   */
   public FeatureFlagContext {
     Objects.requireNonNull(userIdentifier, "userIdentifier must not be null");
     if (userIdentifier.isBlank()) {

--- a/core/src/main/java/net/brightroom/featureflag/core/event/FeatureFlagChangedEvent.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/event/FeatureFlagChangedEvent.java
@@ -17,8 +17,13 @@ import org.springframework.context.ApplicationEvent;
  */
 public class FeatureFlagChangedEvent extends ApplicationEvent {
 
+  /** The name of the feature flag that was changed. */
   private final String featureName;
+
+  /** Whether the feature flag is enabled after this change. */
   private final boolean enabled;
+
+  /** The new rollout percentage, or {@code null} if the rollout was not changed. */
   @Nullable private final Integer rolloutPercentage;
 
   /**

--- a/core/src/main/java/net/brightroom/featureflag/core/event/FeatureFlagRemovedEvent.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/event/FeatureFlagRemovedEvent.java
@@ -16,6 +16,7 @@ import org.springframework.context.ApplicationEvent;
  */
 public class FeatureFlagRemovedEvent extends ApplicationEvent {
 
+  /** The name of the feature flag that was removed. */
   private final String featureName;
 
   /**

--- a/core/src/main/java/net/brightroom/featureflag/core/exception/FeatureFlagAccessDeniedException.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/exception/FeatureFlagAccessDeniedException.java
@@ -10,6 +10,7 @@ public class FeatureFlagAccessDeniedException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
+  /** The name of the feature that is not available. */
   private final String featureName;
 
   /**

--- a/core/src/main/java/net/brightroom/featureflag/core/rollout/DefaultRolloutStrategy.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/rollout/DefaultRolloutStrategy.java
@@ -15,6 +15,9 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
  */
 public class DefaultRolloutStrategy implements RolloutStrategy {
 
+  /** Creates a new {@code DefaultRolloutStrategy}. */
+  public DefaultRolloutStrategy() {}
+
   @Override
   public boolean isInRollout(String featureName, FeatureFlagContext context, int percentage) {
     if (percentage <= 0) return false;


### PR DESCRIPTION
Fix 8 Javadoc warnings in the core module:

- `FeatureFlagContext`: add `@param` for `userIdentifier` record component and Javadoc for compact constructor
- `DefaultRolloutStrategy`: add explicit no-arg constructor with Javadoc
- `FeatureFlagChangedEvent`: add Javadoc to `featureName`, `enabled`, and `rolloutPercentage` fields
- `FeatureFlagRemovedEvent`: add Javadoc to `featureName` field
- `FeatureFlagAccessDeniedException`: add Javadoc to `featureName` field

Closes #189

Generated with [Claude Code](https://claude.ai/code)