### PR TITLE
Close #191: Add missing Javadoc to webmvc module classes and constructors

### DIFF
--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
@@ -22,6 +22,16 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 
+/**
+ * Auto-configuration for Spring MVC feature flag support.
+ *
+ * <p>Registers the core beans required for feature flag enforcement in servlet-based Spring MVC
+ * applications, including {@link net.brightroom.featureflag.core.provider.FeatureFlagProvider},
+ * {@link net.brightroom.featureflag.webmvc.interceptor.FeatureFlagInterceptor}, {@link
+ * net.brightroom.featureflag.webmvc.exception.FeatureFlagExceptionHandler}, and related resolution
+ * and rollout beans. Beans annotated with {@code @ConditionalOnMissingBean} can be replaced by
+ * user-defined beans.
+ */
 @AutoConfiguration(after = FeatureFlagAutoConfiguration.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class FeatureFlagMvcAutoConfiguration {
@@ -91,6 +101,11 @@ public class FeatureFlagMvcAutoConfiguration {
         featureFlagProvider, accessDeniedHandlerFilterResolution, rolloutStrategy, contextResolver);
   }
 
+  /**
+   * Creates a new {@link FeatureFlagMvcAutoConfiguration}.
+   *
+   * @param featureFlagProperties the feature flag configuration properties; must not be null
+   */
   FeatureFlagMvcAutoConfiguration(FeatureFlagProperties featureFlagProperties) {
     this.featureFlagProperties = featureFlagProperties;
   }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcInterceptorRegistrationAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcInterceptorRegistrationAutoConfiguration.java
@@ -6,9 +6,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * Auto-configuration that registers {@link
+ * net.brightroom.featureflag.webmvc.interceptor.FeatureFlagInterceptor} with the Spring MVC
+ * interceptor registry for all request paths ({@code /**}).
+ *
+ * <p>This configuration runs after {@link FeatureFlagMvcAutoConfiguration} to ensure the
+ * interceptor bean is available before registration.
+ */
 @AutoConfiguration(after = FeatureFlagMvcAutoConfiguration.class)
 public class FeatureFlagMvcInterceptorRegistrationAutoConfiguration {
 
+  /** Creates a new {@link FeatureFlagMvcInterceptorRegistrationAutoConfiguration}. */
   FeatureFlagMvcInterceptorRegistrationAutoConfiguration() {}
 
   @Configuration(proxyBeanMethods = false)

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/context/RandomFeatureFlagContextResolver.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/context/RandomFeatureFlagContextResolver.java
@@ -16,6 +16,9 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
  */
 public class RandomFeatureFlagContextResolver implements FeatureFlagContextResolver {
 
+  /** Creates a new {@link RandomFeatureFlagContextResolver}. */
+  public RandomFeatureFlagContextResolver() {}
+
   @Override
   public Optional<FeatureFlagContext> resolve(HttpServletRequest request) {
     return Optional.of(new FeatureFlagContext(UUID.randomUUID().toString()));

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/exception/FeatureFlagExceptionHandler.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/exception/FeatureFlagExceptionHandler.java
@@ -31,6 +31,12 @@ public class FeatureFlagExceptionHandler {
     return accessDeniedInterceptResolution.resolution(request, e);
   }
 
+  /**
+   * Creates a new {@link FeatureFlagExceptionHandler} with the given resolution strategy.
+   *
+   * @param accessDeniedInterceptResolution the resolution to use when access is denied; must not be
+   *     null
+   */
   public FeatureFlagExceptionHandler(
       AccessDeniedInterceptResolution accessDeniedInterceptResolution) {
     this.accessDeniedInterceptResolution = accessDeniedInterceptResolution;

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -86,6 +86,17 @@ public class FeatureFlagHandlerFilterFunction {
     };
   }
 
+  /**
+   * Creates a new {@link FeatureFlagHandlerFilterFunction}.
+   *
+   * @param featureFlagProvider the provider used to check whether a feature flag is enabled; must
+   *     not be null
+   * @param resolution the resolution strategy invoked when access is denied; must not be null
+   * @param rolloutStrategy the strategy used to determine rollout bucket membership; must not be
+   *     null
+   * @param contextResolver the resolver used to obtain the feature flag context from the request;
+   *     must not be null
+   */
   public FeatureFlagHandlerFilterFunction(
       FeatureFlagProvider featureFlagProvider,
       AccessDeniedHandlerFilterResolution resolution,

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
@@ -14,12 +14,33 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+/**
+ * Spring MVC interceptor that enforces feature flag access control on annotated controllers.
+ *
+ * <p>Checks the {@link net.brightroom.featureflag.core.annotation.FeatureFlag} annotation on the
+ * handler method first, then on the handler class. Method-level annotations take priority over
+ * class-level annotations. If the feature is disabled, a {@link
+ * net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException} is thrown and handled
+ * by {@link net.brightroom.featureflag.webmvc.exception.FeatureFlagExceptionHandler}.
+ */
 public class FeatureFlagInterceptor implements HandlerInterceptor {
   private final FeatureFlagProvider featureFlagProvider;
   private final RolloutStrategy rolloutStrategy;
   private final FeatureFlagContextResolver contextResolver;
   private final RolloutPercentageProvider rolloutPercentageProvider;
 
+  /**
+   * Creates a new {@link FeatureFlagInterceptor}.
+   *
+   * @param featureFlagProvider the provider used to check whether a feature flag is enabled; must
+   *     not be null
+   * @param rolloutStrategy the strategy used to determine rollout bucket membership; must not be
+   *     null
+   * @param contextResolver the resolver used to obtain the feature flag context from the request;
+   *     must not be null
+   * @param rolloutPercentageProvider the provider that supplies per-flag rollout percentages,
+   *     overriding annotation-level values when present; must not be null
+   */
   public FeatureFlagInterceptor(
       FeatureFlagProvider featureFlagProvider,
       RolloutStrategy rolloutStrategy,

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/AccessDeniedInterceptResolutionFactory.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/AccessDeniedInterceptResolutionFactory.java
@@ -3,8 +3,23 @@ package net.brightroom.featureflag.webmvc.resolution;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.properties.ResponseProperties;
 
+/**
+ * Factory for creating {@link AccessDeniedInterceptResolution} instances based on the configured
+ * response type.
+ *
+ * <p>Selects the appropriate resolution implementation from {@link
+ * net.brightroom.featureflag.core.properties.ResponseProperties.ResponseType} configured via {@code
+ * feature-flags.response.type}.
+ */
 public class AccessDeniedInterceptResolutionFactory {
 
+  /**
+   * Creates an {@link AccessDeniedInterceptResolution} appropriate for the response type configured
+   * in the given properties.
+   *
+   * @param featureFlagProperties the feature flag configuration properties; must not be null
+   * @return the resolution implementation matching the configured response type
+   */
   public AccessDeniedInterceptResolution create(FeatureFlagProperties featureFlagProperties) {
     ResponseProperties responseProperties = featureFlagProperties.response();
 
@@ -15,5 +30,6 @@ public class AccessDeniedInterceptResolutionFactory {
     };
   }
 
+  /** Creates a new {@link AccessDeniedInterceptResolutionFactory}. */
   public AccessDeniedInterceptResolutionFactory() {}
 }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
@@ -3,8 +3,23 @@ package net.brightroom.featureflag.webmvc.resolution.handlerfilter;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.properties.ResponseProperties;
 
+/**
+ * Factory for creating {@link AccessDeniedHandlerFilterResolution} instances based on the
+ * configured response type.
+ *
+ * <p>Selects the appropriate resolution implementation from {@link
+ * net.brightroom.featureflag.core.properties.ResponseProperties.ResponseType} configured via {@code
+ * feature-flags.response.type}.
+ */
 public class AccessDeniedHandlerFilterResolutionFactory {
 
+  /**
+   * Creates an {@link AccessDeniedHandlerFilterResolution} appropriate for the response type
+   * configured in the given properties.
+   *
+   * @param featureFlagProperties the feature flag configuration properties; must not be null
+   * @return the resolution implementation matching the configured response type
+   */
   public AccessDeniedHandlerFilterResolution create(FeatureFlagProperties featureFlagProperties) {
     ResponseProperties responseProperties = featureFlagProperties.response();
 
@@ -15,5 +30,6 @@ public class AccessDeniedHandlerFilterResolutionFactory {
     };
   }
 
+  /** Creates a new {@link AccessDeniedHandlerFilterResolutionFactory}. */
   public AccessDeniedHandlerFilterResolutionFactory() {}
 }


### PR DESCRIPTION
Close #191

## Summary

- Add Javadoc comments to 13 locations in the webmvc module that were generating `no comment` warnings during the `javadoc` task
- Added an explicit constructor to `RandomFeatureFlagContextResolver` to resolve the "use of default constructor" warning
- Applied Google Java Format via `spotlessApply`

Generated with [Claude Code](https://claude.ai/code)