### PR TITLE
Close #192: Add missing Javadoc to webflux module (14 warnings)

### DIFF
--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
@@ -17,6 +17,19 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+/**
+ * AOP aspect that enforces feature flag access control on Spring WebFlux controller methods.
+ *
+ * <p>Intercepts methods and classes annotated with {@link
+ * net.brightroom.featureflag.core.annotation.FeatureFlag} via an {@code @Around} advice. If the
+ * referenced feature flag is disabled, a {@link
+ * net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException} is emitted into the
+ * reactive pipeline. The method-level annotation takes priority over the class-level annotation.
+ *
+ * <p>Only reactive return types ({@link reactor.core.publisher.Mono} and {@link
+ * reactor.core.publisher.Flux}) are supported; non-reactive return types throw {@link
+ * IllegalStateException}.
+ */
 @Aspect
 public class FeatureFlagAspect {
 
@@ -25,6 +38,18 @@ public class FeatureFlagAspect {
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
 
+  /**
+   * Around advice that checks the feature flag before proceeding with the annotated method.
+   *
+   * <p>Applies to methods and classes annotated with {@link
+   * net.brightroom.featureflag.core.annotation.FeatureFlag}. If the feature is disabled, a {@link
+   * net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException} is returned in the
+   * reactive pipeline. Rollout percentage is also evaluated when configured.
+   *
+   * @param joinPoint the proceeding join point of the intercepted method
+   * @return the result of the intercepted method, or an error signal if access is denied
+   * @throws Throwable if the underlying method throws an exception
+   */
   @Around(
       "@within(net.brightroom.featureflag.core.annotation.FeatureFlag) || "
           + "@annotation(net.brightroom.featureflag.core.annotation.FeatureFlag)")
@@ -167,6 +192,15 @@ public class FeatureFlagAspect {
     }
   }
 
+  /**
+   * Creates a new {@code FeatureFlagAspect}.
+   *
+   * @param reactiveFeatureFlagProvider the provider used to check whether a feature flag is enabled
+   * @param rolloutStrategy the strategy used to determine rollout bucket membership
+   * @param contextResolver the resolver used to extract context from the current request
+   * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
+   *     feature
+   */
   public FeatureFlagAspect(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
       ReactiveRolloutStrategy rolloutStrategy,

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
@@ -25,6 +25,22 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 
+/**
+ * Auto-configuration for the Spring WebFlux feature flag integration.
+ *
+ * <p>Registers the following beans when running in a reactive web application:
+ *
+ * <ul>
+ *   <li>{@link net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider} — in-memory
+ *       provider backed by {@code feature-flags.feature-names} config (conditional on missing bean)
+ *   <li>{@link net.brightroom.featureflag.webflux.aspect.FeatureFlagAspect} — AOP aspect for
+ *       annotation-based controllers (conditional on missing bean)
+ *   <li>{@link net.brightroom.featureflag.webflux.filter.FeatureFlagHandlerFilterFunction} — filter
+ *       factory for functional endpoints (conditional on missing bean)
+ *   <li>{@link org.springframework.web.server.WebFilter} — propagates {@link
+ *       org.springframework.web.server.ServerWebExchange} into the Reactor context
+ * </ul>
+ */
 @AutoConfiguration(after = FeatureFlagAutoConfiguration.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @EnableAspectJAutoProxy(proxyTargetClass = true)
@@ -120,6 +136,11 @@ public class FeatureFlagWebFluxAutoConfiguration {
         reactiveRolloutPercentageProvider);
   }
 
+  /**
+   * Creates a new {@code FeatureFlagWebFluxAutoConfiguration}.
+   *
+   * @param featureFlagProperties the feature flag configuration properties
+   */
   FeatureFlagWebFluxAutoConfiguration(FeatureFlagProperties featureFlagProperties) {
     this.featureFlagProperties = featureFlagProperties;
   }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/context/RandomReactiveFeatureFlagContextResolver.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/context/RandomReactiveFeatureFlagContextResolver.java
@@ -17,6 +17,9 @@ import reactor.core.publisher.Mono;
 public class RandomReactiveFeatureFlagContextResolver
     implements ReactiveFeatureFlagContextResolver {
 
+  /** Creates a new {@code RandomReactiveFeatureFlagContextResolver}. */
+  public RandomReactiveFeatureFlagContextResolver() {}
+
   @Override
   public Mono<FeatureFlagContext> resolve(ServerHttpRequest request) {
     return Mono.just(new FeatureFlagContext(UUID.randomUUID().toString()));

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/exception/FeatureFlagExceptionHandler.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/exception/FeatureFlagExceptionHandler.java
@@ -31,6 +31,11 @@ public class FeatureFlagExceptionHandler {
     return accessDeniedExceptionHandlerResolution.resolution(request, e);
   }
 
+  /**
+   * Creates a new {@code FeatureFlagExceptionHandler}.
+   *
+   * @param accessDeniedExceptionHandlerResolution the resolution used to build the denied response
+   */
   public FeatureFlagExceptionHandler(
       AccessDeniedExceptionHandlerResolution accessDeniedExceptionHandlerResolution) {
     this.accessDeniedExceptionHandlerResolution = accessDeniedExceptionHandlerResolution;

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -119,6 +119,16 @@ public class FeatureFlagHandlerFilterFunction {
                 });
   }
 
+  /**
+   * Creates a new {@code FeatureFlagHandlerFilterFunction}.
+   *
+   * @param reactiveFeatureFlagProvider the provider used to check whether a feature flag is enabled
+   * @param resolution the resolution used to build the denied response for functional endpoints
+   * @param rolloutStrategy the strategy used to determine rollout bucket membership
+   * @param contextResolver the resolver used to extract context from the current request
+   * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
+   *     feature
+   */
   public FeatureFlagHandlerFilterFunction(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
       AccessDeniedHandlerFilterResolution resolution,

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionFactory.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionFactory.java
@@ -3,8 +3,21 @@ package net.brightroom.featureflag.webflux.resolution.exceptionhandler;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.properties.ResponseProperties;
 
+/**
+ * Factory for creating {@link AccessDeniedExceptionHandlerResolution} instances.
+ *
+ * <p>Selects the appropriate resolution implementation based on the configured {@code
+ * feature-flags.response.type} property.
+ */
 public class AccessDeniedExceptionHandlerResolutionFactory {
 
+  /**
+   * Creates an {@link AccessDeniedExceptionHandlerResolution} based on the response type configured
+   * in the given {@link FeatureFlagProperties}.
+   *
+   * @param featureFlagProperties the feature flag configuration properties
+   * @return the resolution implementation matching the configured response type
+   */
   public AccessDeniedExceptionHandlerResolution create(
       FeatureFlagProperties featureFlagProperties) {
     ResponseProperties responseProperties = featureFlagProperties.response();
@@ -16,5 +29,6 @@ public class AccessDeniedExceptionHandlerResolutionFactory {
     };
   }
 
+  /** Creates a new {@code AccessDeniedExceptionHandlerResolutionFactory}. */
   public AccessDeniedExceptionHandlerResolutionFactory() {}
 }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
@@ -3,8 +3,21 @@ package net.brightroom.featureflag.webflux.resolution.handlerfilter;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.properties.ResponseProperties;
 
+/**
+ * Factory for creating {@link AccessDeniedHandlerFilterResolution} instances.
+ *
+ * <p>Selects the appropriate resolution implementation based on the configured {@code
+ * feature-flags.response.type} property.
+ */
 public class AccessDeniedHandlerFilterResolutionFactory {
 
+  /**
+   * Creates an {@link AccessDeniedHandlerFilterResolution} based on the response type configured in
+   * the given {@link FeatureFlagProperties}.
+   *
+   * @param featureFlagProperties the feature flag configuration properties
+   * @return the resolution implementation matching the configured response type
+   */
   public AccessDeniedHandlerFilterResolution create(FeatureFlagProperties featureFlagProperties) {
     ResponseProperties responseProperties = featureFlagProperties.response();
 
@@ -15,5 +28,6 @@ public class AccessDeniedHandlerFilterResolutionFactory {
     };
   }
 
+  /** Creates a new {@code AccessDeniedHandlerFilterResolutionFactory}. */
   public AccessDeniedHandlerFilterResolutionFactory() {}
 }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/rollout/DefaultReactiveRolloutStrategy.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/rollout/DefaultReactiveRolloutStrategy.java
@@ -11,6 +11,9 @@ import reactor.core.publisher.Mono;
  */
 public class DefaultReactiveRolloutStrategy implements ReactiveRolloutStrategy {
 
+  /** Creates a new {@code DefaultReactiveRolloutStrategy}. */
+  public DefaultReactiveRolloutStrategy() {}
+
   private final DefaultRolloutStrategy delegate = new DefaultRolloutStrategy();
 
   @Override


### PR DESCRIPTION
Close #192

## Summary

- Add missing Javadoc comments to 8 files in the webflux module to resolve 14 `javadoc` task warnings
- Added class, constructor, and method level Javadoc where missing
- Added explicit constructors with Javadoc to `DefaultReactiveRolloutStrategy` and `RandomReactiveFeatureFlagContextResolver` to fix "use of default constructor" warnings

Generated with [Claude Code](https://claude.ai/code)