### PR TITLE
Close #186: test: rename validatePredefinedFunctions to validatePredefinedFeatures

### DIFF
--- a/core/src/test/java/net/brightroom/featureflag/core/provider/InMemoryFeatureFlagProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/InMemoryFeatureFlagProviderTest.java
@@ -25,7 +25,7 @@ class InMemoryFeatureFlagProviderTest {
   }
 
   @Test
-  void validatePredefinedFunctions() {
+  void validatePredefinedFeatures() {
     assertTrue(featureFlagProvider.isFeatureEnabled("experimental-stage-endpoint"));
     assertFalse(featureFlagProvider.isFeatureEnabled("development-stage-endpoint"));
   }


### PR DESCRIPTION
Close #186

## 変更内容

InMemoryFeatureFlagProviderTest のテストメソッド名 `validatePredefinedFunctions` を、テスト内容（事前定義されたフィーチャーフラグの検証）に合わせて `validatePredefinedFeatures` にリネームしました。

Generated with [Claude Code](https://claude.ai/code)