### PR TITLE
Close #188: feat: add rollout range validation to FeatureConfiguration

### DIFF
--- a/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureConfiguration.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureConfiguration.java
@@ -50,6 +50,9 @@ public class FeatureConfiguration {
 
   // for property binding
   void setRollout(int rollout) {
+    if (rollout < 0 || rollout > 100) {
+      throw new IllegalArgumentException("rollout must be between 0 and 100, but was: " + rollout);
+    }
     this.rollout = rollout;
   }
 

--- a/core/src/test/java/net/brightroom/featureflag/core/properties/FeatureConfigurationTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/properties/FeatureConfigurationTest.java
@@ -1,0 +1,35 @@
+package net.brightroom.featureflag.core.properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FeatureConfigurationTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 50, 99, 100})
+  void setRollout_shouldAcceptValidValues(int rollout) {
+    FeatureConfiguration config = new FeatureConfiguration();
+    assertDoesNotThrow(() -> config.setRollout(rollout));
+    assertEquals(rollout, config.rollout());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, -100, 101, 200})
+  void setRollout_shouldRejectOutOfRangeValues(int rollout) {
+    FeatureConfiguration config = new FeatureConfiguration();
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> config.setRollout(rollout));
+    assertTrue(ex.getMessage().contains(String.valueOf(rollout)));
+  }
+
+  @Test
+  void setRollout_errorMessageShouldContainInvalidValue() {
+    FeatureConfiguration config = new FeatureConfiguration();
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> config.setRollout(101));
+    assertEquals("rollout must be between 0 and 100, but was: 101", ex.getMessage());
+  }
+}


### PR DESCRIPTION
Close #188

## Summary

- `FeatureConfiguration.setRollout()` に 0–100 の範囲バリデーションを追加し、設定ミスを早期検出できるようにしました
- `FeatureConfigurationTest` を新規作成し、有効値・無効値のパラメタライズドテストを追加

Generated with [Claude Code](https://claude.ai/code)