### PR TITLE
Close #182: Add validation to setRolloutPercentage in InMemory providers

### DIFF
--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
@@ -35,6 +35,10 @@ public class MutableInMemoryReactiveRolloutPercentageProvider
   /** {@inheritDoc} */
   @Override
   public void setRolloutPercentage(String featureName, int percentage) {
+    if (percentage < 0 || percentage > 100) {
+      throw new IllegalArgumentException(
+          "percentage must be between 0 and 100, but was: " + percentage);
+    }
     rolloutPercentages.put(featureName, percentage);
   }
 

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryRolloutPercentageProvider.java
@@ -34,6 +34,10 @@ public class MutableInMemoryRolloutPercentageProvider implements MutableRolloutP
   /** {@inheritDoc} */
   @Override
   public void setRolloutPercentage(String featureName, int percentage) {
+    if (percentage < 0 || percentage > 100) {
+      throw new IllegalArgumentException(
+          "percentage must be between 0 and 100, but was: " + percentage);
+    }
     rolloutPercentages.put(featureName, percentage);
   }
 

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
@@ -18,7 +18,7 @@ class MutableInMemoryReactiveRolloutPercentageProviderTest {
   void setRolloutPercentage_storesPercentage_whenValueIsValid(int percentage) {
     var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
 
-    provider.setRolloutPercentage("feature-a", percentage);
+    provider.setRolloutPercentage("feature-a", percentage).block();
 
     assertEquals(percentage, provider.getRolloutPercentage("feature-a").block());
   }

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
@@ -2,12 +2,35 @@ package net.brightroom.featureflag.core.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class MutableInMemoryReactiveRolloutPercentageProviderTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 50, 100})
+  void setRolloutPercentage_storesPercentage_whenValueIsValid(int percentage) {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("feature-a", percentage);
+
+    assertEquals(percentage, provider.getRolloutPercentage("feature-a").block());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 101})
+  void setRolloutPercentage_throwsIllegalArgumentException_whenValueIsOutOfRange(int percentage) {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> provider.setRolloutPercentage("feature-a", percentage));
+  }
 
   @Test
   void removeRolloutPercentage_removesExistingEntry() {

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryRolloutPercentageProviderTest.java
@@ -1,13 +1,36 @@
 package net.brightroom.featureflag.core.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class MutableInMemoryRolloutPercentageProviderTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 50, 100})
+  void setRolloutPercentage_storesPercentage_whenValueIsValid(int percentage) {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("feature-a", percentage);
+
+    assertEquals(OptionalInt.of(percentage), provider.getRolloutPercentage("feature-a"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 101})
+  void setRolloutPercentage_throwsIllegalArgumentException_whenValueIsOutOfRange(int percentage) {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> provider.setRolloutPercentage("feature-a", percentage));
+  }
 
   @Test
   void removeRolloutPercentage_removesExistingEntry() {


### PR DESCRIPTION
Close #182

## Summary

- `MutableInMemoryRolloutPercentageProvider.setRolloutPercentage()` にバリデーションを追加
- `MutableInMemoryReactiveRolloutPercentageProvider.setRolloutPercentage()` にバリデーションを追加
- 範囲外（0 未満または 100 超）の値が渡された場合は `IllegalArgumentException` をスロー

Generated with [Claude Code](https://claude.ai/code)