### PR TITLE
Close #180: fix: inject RolloutPercentageProvider into webmvc FeatureFlagHandlerFilterFunction

### DIFF
--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
@@ -96,9 +96,14 @@ public class FeatureFlagMvcAutoConfiguration {
       FeatureFlagProvider featureFlagProvider,
       AccessDeniedHandlerFilterResolution accessDeniedHandlerFilterResolution,
       RolloutStrategy rolloutStrategy,
-      FeatureFlagContextResolver contextResolver) {
+      FeatureFlagContextResolver contextResolver,
+      RolloutPercentageProvider rolloutPercentageProvider) {
     return new FeatureFlagHandlerFilterFunction(
-        featureFlagProvider, accessDeniedHandlerFilterResolution, rolloutStrategy, contextResolver);
+        featureFlagProvider,
+        accessDeniedHandlerFilterResolution,
+        rolloutStrategy,
+        contextResolver,
+        rolloutPercentageProvider);
   }
 
   /**

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
+import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
 import net.brightroom.featureflag.webmvc.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
@@ -40,6 +41,7 @@ public class FeatureFlagHandlerFilterFunction {
   private final AccessDeniedHandlerFilterResolution resolution;
   private final RolloutStrategy rolloutStrategy;
   private final FeatureFlagContextResolver contextResolver;
+  private final RolloutPercentageProvider rolloutPercentageProvider;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
@@ -56,26 +58,35 @@ public class FeatureFlagHandlerFilterFunction {
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
    * and rollout percentage.
    *
+   * <p>The rollout percentage is resolved from the {@link RolloutPercentageProvider} first. If no
+   * rollout percentage is configured in the provider, the {@code rolloutFallback} argument is used
+   * as a fallback.
+   *
    * @param featureName the name of the feature flag to check; must not be null or empty
-   * @param rollout the rollout percentage (0–100); 100 means fully enabled
+   * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
+   *     the provider; 100 means fully enabled
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
    *     and rollout
-   * @throws IllegalArgumentException if {@code featureName} is null or empty, or if {@code rollout}
-   *     is not between 0 and 100
+   * @throws IllegalArgumentException if {@code featureName} is null or empty, or if {@code
+   *     rolloutFallback} is not between 0 and 100
    */
-  public HandlerFilterFunction<ServerResponse, ServerResponse> of(String featureName, int rollout) {
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String featureName, int rolloutFallback) {
     if (featureName == null || featureName.isEmpty()) {
       throw new IllegalArgumentException(
           "featureName must not be null or empty. "
               + "An empty value causes fail-open behavior and allows access unconditionally.");
     }
-    if (rollout < 0 || rollout > 100) {
-      throw new IllegalArgumentException("rollout must be between 0 and 100, but was: " + rollout);
+    if (rolloutFallback < 0 || rolloutFallback > 100) {
+      throw new IllegalArgumentException(
+          "rollout must be between 0 and 100, but was: " + rolloutFallback);
     }
     return (request, next) -> {
       if (!featureFlagProvider.isFeatureEnabled(featureName)) {
         return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
       }
+      int rollout =
+          rolloutPercentageProvider.getRolloutPercentage(featureName).orElse(rolloutFallback);
       if (rollout < 100) {
         Optional<FeatureFlagContext> ctx = contextResolver.resolve(request.servletRequest());
         if (ctx.isPresent() && !rolloutStrategy.isInRollout(featureName, ctx.get(), rollout)) {
@@ -96,15 +107,19 @@ public class FeatureFlagHandlerFilterFunction {
    *     null
    * @param contextResolver the resolver used to obtain the feature flag context from the request;
    *     must not be null
+   * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
+   *     feature; must not be null
    */
   public FeatureFlagHandlerFilterFunction(
       FeatureFlagProvider featureFlagProvider,
       AccessDeniedHandlerFilterResolution resolution,
       RolloutStrategy rolloutStrategy,
-      FeatureFlagContextResolver contextResolver) {
+      FeatureFlagContextResolver contextResolver,
+      RolloutPercentageProvider rolloutPercentageProvider) {
     this.featureFlagProvider = featureFlagProvider;
     this.resolution = resolution;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
+    this.rolloutPercentageProvider = rolloutPercentageProvider;
   }
 }

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -11,9 +11,11 @@ import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
+import java.util.OptionalInt;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
+import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.core.rollout.DefaultRolloutStrategy;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -30,14 +32,21 @@ class FeatureFlagHandlerFilterFunctionTest {
   private final AccessDeniedHandlerFilterResolution resolution =
       mock(AccessDeniedHandlerFilterResolution.class);
   private final FeatureFlagContextResolver contextResolver = mock(FeatureFlagContextResolver.class);
+  private final RolloutPercentageProvider rolloutPercentageProvider =
+      mock(RolloutPercentageProvider.class);
   private final FeatureFlagHandlerFilterFunction filterFunction =
       new FeatureFlagHandlerFilterFunction(
-          provider, resolution, new DefaultRolloutStrategy(), contextResolver);
+          provider,
+          resolution,
+          new DefaultRolloutStrategy(),
+          contextResolver,
+          rolloutPercentageProvider);
 
   // Filter function with mocked rollout strategy for rollout-specific tests
   private final RolloutStrategy rolloutStrategy = mock(RolloutStrategy.class);
   private final FeatureFlagHandlerFilterFunction filterFunctionWithRollout =
-      new FeatureFlagHandlerFilterFunction(provider, resolution, rolloutStrategy, contextResolver);
+      new FeatureFlagHandlerFilterFunction(
+          provider, resolution, rolloutStrategy, contextResolver, rolloutPercentageProvider);
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {
@@ -71,6 +80,8 @@ class FeatureFlagHandlerFilterFunctionTest {
   @SuppressWarnings("unchecked")
   void of_delegatesToNext_whenFeatureEnabled() throws Exception {
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
     ServerRequest request = mock(ServerRequest.class);
     HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
     ServerResponse okResponse = mock(ServerResponse.class);
@@ -106,6 +117,8 @@ class FeatureFlagHandlerFilterFunctionTest {
   @SuppressWarnings("unchecked")
   void of_delegatesToNext_whenRolloutCheckPasses() throws Exception {
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
 
     HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
     ServerRequest request = mock(ServerRequest.class);
@@ -132,6 +145,8 @@ class FeatureFlagHandlerFilterFunctionTest {
   @SuppressWarnings("unchecked")
   void of_delegatesToResolution_whenRolloutCheckFails() throws Exception {
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
 
     HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
     ServerRequest request = mock(ServerRequest.class);
@@ -160,6 +175,8 @@ class FeatureFlagHandlerFilterFunctionTest {
   void of_delegatesToNext_whenContextIsEmpty() throws Exception {
     // fail-open: when context is not available, rollout check is skipped
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
 
     HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
     ServerRequest request = mock(ServerRequest.class);
@@ -178,5 +195,64 @@ class FeatureFlagHandlerFilterFunctionTest {
     assertThat(result).isEqualTo(okResponse);
     verify(next).handle(request);
     verifyNoInteractions(resolution);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_usesProviderRollout_whenProviderReturnsValue() throws Exception {
+    // Provider returns 70, fallback is 50 — provider value takes precedence
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.of(70));
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.servletRequest()).thenReturn(httpServletRequest);
+
+    FeatureFlagContext context = new FeatureFlagContext("user-1");
+    when(contextResolver.resolve(httpServletRequest)).thenReturn(Optional.of(context));
+    when(rolloutStrategy.isInRollout("my-feature", context, 70)).thenReturn(true);
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(okResponse);
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-feature", 50);
+    ServerResponse result = filter.filter(request, next);
+
+    assertThat(result).isEqualTo(okResponse);
+    verify(rolloutStrategy).isInRollout("my-feature", context, 70);
+    verify(next).handle(request);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_usesFallbackRollout_whenProviderReturnsEmpty() throws Exception {
+    // Provider returns empty, fallback 30 is used
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.servletRequest()).thenReturn(httpServletRequest);
+
+    FeatureFlagContext context = new FeatureFlagContext("user-1");
+    when(contextResolver.resolve(httpServletRequest)).thenReturn(Optional.of(context));
+    when(rolloutStrategy.isInRollout("my-feature", context, 30)).thenReturn(false);
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(FeatureFlagAccessDeniedException.class)))
+        .thenReturn(deniedResponse);
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-feature", 30);
+    ServerResponse result = filter.filter(request, next);
+
+    assertThat(result).isEqualTo(deniedResponse);
+    verify(rolloutStrategy).isInRollout("my-feature", context, 30);
+    verifyNoInteractions(next);
   }
 }


### PR DESCRIPTION
Close #180

## Summary

- webmvc の `FeatureFlagHandlerFilterFunction` に `RolloutPercentageProvider` を注入し、ロールアウト率を動的に解決するよう修正
- `of()` 引数の `rollout` を `rolloutFallback` にリネーム（webflux と統一）
- `FeatureFlagMvcAutoConfiguration` の Bean 定義に `RolloutPercentageProvider` パラメータを追加
- テストを更新し、プロバイダ値が優先されること・空の場合はフォールバックを使うことを検証するテストを 2 件追加

Generated with [Claude Code](https://claude.ai/code)