### PR TITLE
Close #179: Make MutableReactiveRolloutPercentageProvider methods reactive

### DIFF
--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
@@ -87,7 +87,7 @@ public class ReactiveFeatureFlagEndpoint {
     }
     provider.setFeatureEnabled(featureName, enabled).block();
     if (rollout != null) {
-      rolloutProvider.setRolloutPercentage(featureName, rollout);
+      rolloutProvider.setRolloutPercentage(featureName, rollout).block();
     }
     eventPublisher.publishEvent(new FeatureFlagChangedEvent(this, featureName, enabled, rollout));
     return buildFlagsResponse();
@@ -109,7 +109,7 @@ public class ReactiveFeatureFlagEndpoint {
       throw new IllegalArgumentException("featureName must not be null or blank");
     }
     Boolean removed = provider.removeFeature(featureName).block();
-    rolloutProvider.removeRolloutPercentage(featureName);
+    rolloutProvider.removeRolloutPercentage(featureName).block();
     if (Boolean.TRUE.equals(removed)) {
       eventPublisher.publishEvent(new FeatureFlagRemovedEvent(this, featureName));
     }

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfigurationTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfigurationTest.java
@@ -310,13 +310,13 @@ class FeatureFlagActuatorAutoConfigurationTest {
     }
 
     @Override
-    public void setRolloutPercentage(String featureName, int percentage) {
-      store.put(featureName, percentage);
+    public Mono<Void> setRolloutPercentage(String featureName, int percentage) {
+      return Mono.<Void>fromRunnable(() -> store.put(featureName, percentage));
     }
 
     @Override
-    public void removeRolloutPercentage(String featureName) {
-      store.remove(featureName);
+    public Mono<Boolean> removeRolloutPercentage(String featureName) {
+      return Mono.fromCallable(() -> store.remove(featureName) != null);
     }
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
@@ -34,14 +34,14 @@ public class MutableInMemoryReactiveRolloutPercentageProvider
 
   /** {@inheritDoc} */
   @Override
-  public void setRolloutPercentage(String featureName, int percentage) {
-    rolloutPercentages.put(featureName, percentage);
+  public Mono<Void> setRolloutPercentage(String featureName, int percentage) {
+    return Mono.<Void>fromRunnable(() -> rolloutPercentages.put(featureName, percentage));
   }
 
   /** {@inheritDoc} */
   @Override
-  public void removeRolloutPercentage(String featureName) {
-    rolloutPercentages.remove(featureName);
+  public Mono<Boolean> removeRolloutPercentage(String featureName) {
+    return Mono.fromCallable(() -> rolloutPercentages.remove(featureName) != null);
   }
 
   /**

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableReactiveRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableReactiveRolloutPercentageProvider.java
@@ -34,15 +34,19 @@ public interface MutableReactiveRolloutPercentageProvider
    *
    * @param featureName the name of the feature flag to update
    * @param percentage the new rollout percentage (0–100)
+   * @return a {@link Mono} that completes when the update is applied
    */
-  void setRolloutPercentage(String featureName, int percentage);
+  Mono<Void> setRolloutPercentage(String featureName, int percentage);
 
   /**
    * Removes the rollout percentage for the specified feature flag.
    *
-   * <p>If the feature flag does not have a configured rollout percentage, this method is a no-op.
+   * <p>If the feature flag does not have a configured rollout percentage, this method is a no-op
+   * and emits {@code false}.
    *
    * @param featureName the name of the feature flag whose rollout percentage to remove
+   * @return a {@link Mono} emitting {@code true} if the rollout percentage existed and was removed,
+   *     {@code false} if it did not exist
    */
-  void removeRolloutPercentage(String featureName);
+  Mono<Boolean> removeRolloutPercentage(String featureName);
 }

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
@@ -1,6 +1,7 @@
 package net.brightroom.featureflag.core.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,8 +14,9 @@ class MutableInMemoryReactiveRolloutPercentageProviderTest {
   void removeRolloutPercentage_removesExistingEntry() {
     var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
 
-    provider.removeRolloutPercentage("feature-a");
+    Boolean removed = provider.removeRolloutPercentage("feature-a").block();
 
+    assertTrue(removed);
     assertNull(provider.getRolloutPercentage("feature-a").block());
     assertTrue(provider.getRolloutPercentages().block().isEmpty());
   }
@@ -23,8 +25,9 @@ class MutableInMemoryReactiveRolloutPercentageProviderTest {
   void removeRolloutPercentage_isNoOp_whenEntryDoesNotExist() {
     var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
 
-    provider.removeRolloutPercentage("nonexistent");
+    Boolean removed = provider.removeRolloutPercentage("nonexistent").block();
 
+    assertFalse(removed);
     assertEquals(50, provider.getRolloutPercentage("feature-a").block());
     assertEquals(Map.of("feature-a", 50), provider.getRolloutPercentages().block());
   }


### PR DESCRIPTION
Close #179

## Summary

- `setRolloutPercentage` の戻り値を `void` から `Mono<Void>` に変更
- `removeRolloutPercentage` の戻り値を `void` から `Mono<Boolean>` に変更（フラグが存在し削除された場合 true）
- `MutableInMemoryReactiveRolloutPercentageProvider` の実装を Mono でラップ
- `ReactiveFeatureFlagEndpoint` の呼び出し箇所を .block() で対応
- 関連テストを更新

Generated with [Claude Code](https://claude.ai/code)