### PR TITLE
Close #184: test: add missing test coverage for RolloutPercentageProvider

### DIFF
--- a/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
@@ -55,7 +55,7 @@ class MutableInMemoryReactiveRolloutPercentageProviderTest {
   void setRolloutPercentage_addsNewEntry() {
     var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
 
-    provider.setRolloutPercentage("feature-a", 75);
+    provider.setRolloutPercentage("feature-a", 75).block();
 
     assertEquals(75, provider.getRolloutPercentage("feature-a").block());
     assertEquals(Map.of("feature-a", 75), provider.getRolloutPercentages().block());
@@ -65,7 +65,7 @@ class MutableInMemoryReactiveRolloutPercentageProviderTest {
   void setRolloutPercentage_updatesExistingEntry() {
     var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
 
-    provider.setRolloutPercentage("feature-a", 80);
+    provider.setRolloutPercentage("feature-a", 80).block();
 
     assertEquals(80, provider.getRolloutPercentage("feature-a").block());
   }
@@ -86,7 +86,7 @@ class MutableInMemoryReactiveRolloutPercentageProviderTest {
     var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
     var snapshot = provider.getRolloutPercentages().block();
 
-    provider.setRolloutPercentage("feature-a", 80);
+    provider.setRolloutPercentage("feature-a", 80).block();
 
     assertEquals(50, snapshot.get("feature-a"), "snapshot must not reflect subsequent mutations");
   }
@@ -102,7 +102,7 @@ class MutableInMemoryReactiveRolloutPercentageProviderTest {
 
     try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
       for (String feature : features) {
-        executor.submit(() -> provider.setRolloutPercentage(feature, 50));
+        executor.submit(() -> provider.setRolloutPercentage(feature, 50).block());
       }
     }
 

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
@@ -4,10 +4,87 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
 class MutableInMemoryReactiveRolloutPercentageProviderTest {
+
+  @Test
+  void getRolloutPercentage_returnsPercentage_whenExists() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
+
+    assertEquals(50, provider.getRolloutPercentage("feature-a").block());
+  }
+
+  @Test
+  void getRolloutPercentage_returnsEmpty_whenNotExists() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    assertNull(provider.getRolloutPercentage("nonexistent").block());
+  }
+
+  @Test
+  void setRolloutPercentage_addsNewEntry() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("feature-a", 75);
+
+    assertEquals(75, provider.getRolloutPercentage("feature-a").block());
+    assertEquals(Map.of("feature-a", 75), provider.getRolloutPercentages().block());
+  }
+
+  @Test
+  void setRolloutPercentage_updatesExistingEntry() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
+
+    provider.setRolloutPercentage("feature-a", 80);
+
+    assertEquals(80, provider.getRolloutPercentage("feature-a").block());
+  }
+
+  @Test
+  void getRolloutPercentages_returnsSnapshotOfAllPercentages() {
+    var provider =
+        new MutableInMemoryReactiveRolloutPercentageProvider(
+            Map.of("feature-a", 50, "feature-b", 100));
+
+    var percentages = provider.getRolloutPercentages().block();
+
+    assertEquals(Map.of("feature-a", 50, "feature-b", 100), percentages);
+  }
+
+  @Test
+  void getRolloutPercentages_returnsImmutableCopy_notAffectedBySubsequentMutations() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
+    var snapshot = provider.getRolloutPercentages().block();
+
+    provider.setRolloutPercentage("feature-a", 80);
+
+    assertEquals(50, snapshot.get("feature-a"), "snapshot must not reflect subsequent mutations");
+  }
+
+  @Test
+  void concurrentSetRolloutPercentage_doesNotCorruptState() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+    int threadCount = 100;
+    List<String> features = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      features.add("feature-" + i);
+    }
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (String feature : features) {
+        executor.submit(() -> provider.setRolloutPercentage(feature, 50));
+      }
+    }
+
+    assertEquals(threadCount, provider.getRolloutPercentages().block().size());
+    features.forEach(feature -> assertEquals(50, provider.getRolloutPercentage(feature).block()));
+  }
 
   @Test
   void removeRolloutPercentage_removesExistingEntry() {

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/MutableInMemoryRolloutPercentageProviderTest.java
@@ -3,11 +3,88 @@ package net.brightroom.featureflag.core.provider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
 class MutableInMemoryRolloutPercentageProviderTest {
+
+  @Test
+  void getRolloutPercentage_returnsPercentage_whenExists() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("feature-a", 50));
+
+    assertEquals(OptionalInt.of(50), provider.getRolloutPercentage("feature-a"));
+  }
+
+  @Test
+  void getRolloutPercentage_returnsEmpty_whenNotExists() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    assertEquals(OptionalInt.empty(), provider.getRolloutPercentage("nonexistent"));
+  }
+
+  @Test
+  void setRolloutPercentage_addsNewEntry() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("feature-a", 75);
+
+    assertEquals(OptionalInt.of(75), provider.getRolloutPercentage("feature-a"));
+    assertEquals(Map.of("feature-a", 75), provider.getRolloutPercentages());
+  }
+
+  @Test
+  void setRolloutPercentage_updatesExistingEntry() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("feature-a", 50));
+
+    provider.setRolloutPercentage("feature-a", 80);
+
+    assertEquals(OptionalInt.of(80), provider.getRolloutPercentage("feature-a"));
+  }
+
+  @Test
+  void getRolloutPercentages_returnsSnapshotOfAllPercentages() {
+    var provider =
+        new MutableInMemoryRolloutPercentageProvider(Map.of("feature-a", 50, "feature-b", 100));
+
+    var percentages = provider.getRolloutPercentages();
+
+    assertEquals(Map.of("feature-a", 50, "feature-b", 100), percentages);
+  }
+
+  @Test
+  void getRolloutPercentages_returnsImmutableCopy_notAffectedBySubsequentMutations() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("feature-a", 50));
+    var snapshot = provider.getRolloutPercentages();
+
+    provider.setRolloutPercentage("feature-a", 80);
+
+    assertEquals(50, snapshot.get("feature-a"), "snapshot must not reflect subsequent mutations");
+  }
+
+  @Test
+  void concurrentSetRolloutPercentage_doesNotCorruptState() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+    int threadCount = 100;
+    List<String> features = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      features.add("feature-" + i);
+    }
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (String feature : features) {
+        executor.submit(() -> provider.setRolloutPercentage(feature, 50));
+      }
+    }
+
+    assertEquals(threadCount, provider.getRolloutPercentages().size());
+    features.forEach(
+        feature -> assertEquals(OptionalInt.of(50), provider.getRolloutPercentage(feature)));
+  }
 
   @Test
   void removeRolloutPercentage_removesExistingEntry() {


### PR DESCRIPTION
Close #184

## Summary

- `getRolloutPercentage`, `setRolloutPercentage`, `getRolloutPercentages`, および並行テストを `MutableInMemoryRolloutPercentageProviderTest` と `MutableInMemoryReactiveRolloutPercentageProviderTest` に追加
- `MutableInMemoryFeatureFlagProviderTest` で確立されたカバレッジパターンと同等

Generated with [Claude Code](https://claude.ai/code)