### PR TITLE
Close #177: feat(actuator): add timeout configuration for health indicator

### DIFF
--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
@@ -3,6 +3,7 @@ package net.brightroom.featureflag.actuator.autoconfigure;
 import net.brightroom.featureflag.actuator.endpoint.FeatureFlagEndpoint;
 import net.brightroom.featureflag.actuator.endpoint.ReactiveFeatureFlagEndpoint;
 import net.brightroom.featureflag.actuator.health.FeatureFlagHealthIndicator;
+import net.brightroom.featureflag.actuator.health.FeatureFlagHealthProperties;
 import net.brightroom.featureflag.actuator.health.ReactiveFeatureFlagHealthIndicator;
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
@@ -22,6 +23,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -50,6 +52,7 @@ import org.springframework.context.annotation.Configuration;
       "net.brightroom.featureflag.webmvc.autoconfigure.FeatureFlagMvcAutoConfiguration",
       "net.brightroom.featureflag.webflux.autoconfigure.FeatureFlagWebFluxAutoConfiguration"
     })
+@EnableConfigurationProperties(FeatureFlagHealthProperties.class)
 public class FeatureFlagActuatorAutoConfiguration {
 
   /** Creates a new {@link FeatureFlagActuatorAutoConfiguration}. */
@@ -60,6 +63,7 @@ public class FeatureFlagActuatorAutoConfiguration {
   static class ServletConfiguration {
 
     private final FeatureFlagProperties featureFlagProperties;
+    private final FeatureFlagHealthProperties featureFlagHealthProperties;
 
     /**
      * Registers a {@link MutableInMemoryFeatureFlagProvider} bean when no other {@link
@@ -98,7 +102,8 @@ public class FeatureFlagActuatorAutoConfiguration {
     @Bean
     @ConditionalOnEnabledHealthIndicator("featureFlag")
     FeatureFlagHealthIndicator featureFlagHealthIndicator(FeatureFlagProvider provider) {
-      return new FeatureFlagHealthIndicator(provider, featureFlagProperties);
+      return new FeatureFlagHealthIndicator(
+          provider, featureFlagProperties, featureFlagHealthProperties.timeout());
     }
 
     /**
@@ -120,8 +125,11 @@ public class FeatureFlagActuatorAutoConfiguration {
           provider, rolloutProvider, featureFlagProperties.defaultEnabled(), eventPublisher);
     }
 
-    ServletConfiguration(FeatureFlagProperties featureFlagProperties) {
+    ServletConfiguration(
+        FeatureFlagProperties featureFlagProperties,
+        FeatureFlagHealthProperties featureFlagHealthProperties) {
       this.featureFlagProperties = featureFlagProperties;
+      this.featureFlagHealthProperties = featureFlagHealthProperties;
     }
   }
 
@@ -130,6 +138,7 @@ public class FeatureFlagActuatorAutoConfiguration {
   static class ReactiveConfiguration {
 
     private final FeatureFlagProperties featureFlagProperties;
+    private final FeatureFlagHealthProperties featureFlagHealthProperties;
 
     /**
      * Registers a {@link MutableInMemoryReactiveFeatureFlagProvider} bean when no other {@link
@@ -170,7 +179,8 @@ public class FeatureFlagActuatorAutoConfiguration {
     @ConditionalOnEnabledHealthIndicator("featureFlag")
     ReactiveFeatureFlagHealthIndicator featureFlagHealthIndicator(
         ReactiveFeatureFlagProvider provider) {
-      return new ReactiveFeatureFlagHealthIndicator(provider, featureFlagProperties);
+      return new ReactiveFeatureFlagHealthIndicator(
+          provider, featureFlagProperties, featureFlagHealthProperties.timeout());
     }
 
     /**
@@ -192,8 +202,11 @@ public class FeatureFlagActuatorAutoConfiguration {
           provider, rolloutProvider, featureFlagProperties.defaultEnabled(), eventPublisher);
     }
 
-    ReactiveConfiguration(FeatureFlagProperties featureFlagProperties) {
+    ReactiveConfiguration(
+        FeatureFlagProperties featureFlagProperties,
+        FeatureFlagHealthProperties featureFlagHealthProperties) {
       this.featureFlagProperties = featureFlagProperties;
+      this.featureFlagHealthProperties = featureFlagHealthProperties;
     }
   }
 }

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicator.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicator.java
@@ -1,7 +1,10 @@
 package net.brightroom.featureflag.actuator.health;
 
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableFeatureFlagProvider;
@@ -15,7 +18,7 @@ import org.springframework.boot.health.contributor.Health;
  * <p>Reports {@link org.springframework.boot.health.contributor.Status#UP UP} when the provider
  * responds normally and flag information can be retrieved, and {@link
  * org.springframework.boot.health.contributor.Status#DOWN DOWN} when an exception occurs during the
- * health check.
+ * health check or when the provider does not respond within the configured timeout.
  *
  * <p>Health details include:
  *
@@ -31,36 +34,40 @@ import org.springframework.boot.health.contributor.Health;
  * via {@link MutableFeatureFlagProvider#getFeatures()}. Otherwise, the configured feature names
  * from {@link FeatureFlagProperties} are probed individually via {@link
  * FeatureFlagProvider#isFeatureEnabled(String)}.
+ *
+ * <p>When a timeout is configured via {@link FeatureFlagHealthProperties#timeout()}, the health
+ * check will report {@code DOWN} if the provider does not respond within that duration.
  */
 public class FeatureFlagHealthIndicator extends AbstractHealthIndicator {
 
   private final FeatureFlagProvider provider;
   private final FeatureFlagProperties properties;
+  private final Duration timeout;
 
   /**
    * Creates a new {@link FeatureFlagHealthIndicator}.
    *
    * @param provider the feature flag provider to check
    * @param properties the feature flag configuration properties
+   * @param timeout the maximum time to wait for the provider, or {@code null} for no timeout
    */
   public FeatureFlagHealthIndicator(
-      FeatureFlagProvider provider, FeatureFlagProperties properties) {
+      FeatureFlagProvider provider, FeatureFlagProperties properties, Duration timeout) {
     super("Feature flag health check failed");
     this.provider = provider;
     this.properties = properties;
+    this.timeout = timeout;
   }
 
   @Override
-  protected void doHealthCheck(Health.Builder builder) {
+  protected void doHealthCheck(Health.Builder builder) throws Exception {
     Map<String, Boolean> features;
-    if (provider instanceof MutableFeatureFlagProvider mutableProvider) {
-      features = mutableProvider.getFeatures();
+    if (timeout != null) {
+      features =
+          CompletableFuture.supplyAsync(this::fetchFeatures)
+              .get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } else {
-      var map = new LinkedHashMap<String, Boolean>();
-      for (String name : properties.featureNames().keySet()) {
-        map.put(name, provider.isFeatureEnabled(name));
-      }
-      features = map;
+      features = fetchFeatures();
     }
 
     long totalCount = features.size();
@@ -74,5 +81,16 @@ public class FeatureFlagHealthIndicator extends AbstractHealthIndicator {
         .withDetail("enabledFlags", enabledCount)
         .withDetail("disabledFlags", disabledCount)
         .withDetail("defaultEnabled", properties.defaultEnabled());
+  }
+
+  private Map<String, Boolean> fetchFeatures() {
+    if (provider instanceof MutableFeatureFlagProvider mutableProvider) {
+      return mutableProvider.getFeatures();
+    }
+    var map = new LinkedHashMap<String, Boolean>();
+    for (String name : properties.featureNames().keySet()) {
+      map.put(name, provider.isFeatureEnabled(name));
+    }
+    return map;
   }
 }

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthProperties.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthProperties.java
@@ -1,0 +1,43 @@
+package net.brightroom.featureflag.actuator.health;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the feature flag health indicator.
+ *
+ * <p>Configuration example in {@code application.yml}:
+ *
+ * <pre>{@code
+ * management:
+ *   health:
+ *     feature-flag:
+ *       timeout: 5s
+ * }</pre>
+ */
+@ConfigurationProperties(prefix = "management.health.feature-flag")
+public class FeatureFlagHealthProperties {
+
+  /**
+   * Maximum time to wait for the feature flag provider to respond during a health check. When the
+   * provider does not respond within this duration, the health status is reported as {@code DOWN}.
+   * If not set, there is no timeout.
+   */
+  private Duration timeout;
+
+  /**
+   * Returns the health check timeout.
+   *
+   * @return the timeout duration, or {@code null} if no timeout is configured
+   */
+  public Duration timeout() {
+    return timeout;
+  }
+
+  // for property binding
+  void setTimeout(Duration timeout) {
+    this.timeout = timeout;
+  }
+
+  FeatureFlagHealthProperties() {}
+}

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicator.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicator.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.actuator.health;
 
+import java.time.Duration;
 import java.util.Map;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
@@ -16,7 +17,7 @@ import reactor.core.publisher.Mono;
  * <p>Reports {@link org.springframework.boot.health.contributor.Status#UP UP} when the provider
  * responds normally and flag information can be retrieved, and {@link
  * org.springframework.boot.health.contributor.Status#DOWN DOWN} when an exception occurs during the
- * health check.
+ * health check or when the provider does not respond within the configured timeout.
  *
  * <p>Health details include:
  *
@@ -32,23 +33,29 @@ import reactor.core.publisher.Mono;
  * retrieved via {@link MutableReactiveFeatureFlagProvider#getFeatures()}. Otherwise, the configured
  * feature names from {@link FeatureFlagProperties} are probed individually via {@link
  * ReactiveFeatureFlagProvider#isFeatureEnabled(String)}.
+ *
+ * <p>When a timeout is configured via {@link FeatureFlagHealthProperties#timeout()}, the health
+ * check will report {@code DOWN} if the provider does not respond within that duration.
  */
 public class ReactiveFeatureFlagHealthIndicator extends AbstractReactiveHealthIndicator {
 
   private final ReactiveFeatureFlagProvider provider;
   private final FeatureFlagProperties properties;
+  private final Duration timeout;
 
   /**
    * Creates a new {@link ReactiveFeatureFlagHealthIndicator}.
    *
    * @param provider the reactive feature flag provider to check
    * @param properties the feature flag configuration properties
+   * @param timeout the maximum time to wait for the provider, or {@code null} for no timeout
    */
   public ReactiveFeatureFlagHealthIndicator(
-      ReactiveFeatureFlagProvider provider, FeatureFlagProperties properties) {
+      ReactiveFeatureFlagProvider provider, FeatureFlagProperties properties, Duration timeout) {
     super("Feature flag health check failed");
     this.provider = provider;
     this.properties = properties;
+    this.timeout = timeout;
   }
 
   @Override
@@ -62,6 +69,10 @@ public class ReactiveFeatureFlagHealthIndicator extends AbstractReactiveHealthIn
               .flatMap(
                   name -> provider.isFeatureEnabled(name).map(enabled -> Map.entry(name, enabled)))
               .collectMap(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    if (timeout != null) {
+      featuresMono = featuresMono.timeout(timeout);
     }
 
     return featuresMono.map(

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicatorTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicatorTest.java
@@ -119,8 +119,7 @@ class FeatureFlagHealthIndicatorTest {
           return true;
         };
     when(properties.featureNames()).thenReturn(Map.of("feature-a", true));
-    var indicator =
-        new FeatureFlagHealthIndicator(provider, properties, Duration.ofMillis(100));
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, Duration.ofMillis(100));
 
     Health health = indicator.health();
 

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicatorTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicatorTest.java
@@ -3,6 +3,7 @@ package net.brightroom.featureflag.actuator.health;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Map;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -25,7 +26,7 @@ class FeatureFlagHealthIndicatorTest {
         new MutableInMemoryFeatureFlagProvider(
             Map.of("feature-a", true, "feature-b", false), false);
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new FeatureFlagHealthIndicator(provider, properties);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health();
 
@@ -43,7 +44,7 @@ class FeatureFlagHealthIndicatorTest {
     FeatureFlagProvider provider = featureName -> "feature-a".equals(featureName);
     when(properties.featureNames()).thenReturn(Map.of("feature-a", true, "feature-b", false));
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new FeatureFlagHealthIndicator(provider, properties);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health();
 
@@ -61,7 +62,7 @@ class FeatureFlagHealthIndicatorTest {
           throw new RuntimeException("Connection refused");
         };
     when(properties.featureNames()).thenReturn(Map.of("feature-a", true));
-    var indicator = new FeatureFlagHealthIndicator(provider, properties);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health();
 
@@ -73,7 +74,7 @@ class FeatureFlagHealthIndicatorTest {
   void health_isUp_withNoFlags() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new FeatureFlagHealthIndicator(provider, properties);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health();
 
@@ -88,7 +89,7 @@ class FeatureFlagHealthIndicatorTest {
   void health_reflectsDefaultEnabled_true() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), true);
     when(properties.defaultEnabled()).thenReturn(true);
-    var indicator = new FeatureFlagHealthIndicator(provider, properties);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health();
 
@@ -99,10 +100,42 @@ class FeatureFlagHealthIndicatorTest {
   void health_includesProviderClassName() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new FeatureFlagHealthIndicator(provider, properties);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health();
 
     assertThat(health.getDetails()).containsEntry("provider", "MutableInMemoryFeatureFlagProvider");
+  }
+
+  @Test
+  void health_isDown_whenProviderExceedsTimeout() throws InterruptedException {
+    FeatureFlagProvider provider =
+        featureName -> {
+          try {
+            Thread.sleep(5_000);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          return true;
+        };
+    when(properties.featureNames()).thenReturn(Map.of("feature-a", true));
+    var indicator =
+        new FeatureFlagHealthIndicator(provider, properties, Duration.ofMillis(100));
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(health.getDetails()).containsKey("error");
+  }
+
+  @Test
+  void health_isUp_whenProviderRespondsWithinTimeout() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, Duration.ofSeconds(5));
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
   }
 }

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicatorTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicatorTest.java
@@ -144,8 +144,7 @@ class ReactiveFeatureFlagHealthIndicatorTest {
     ReactiveHealthDetailsContributor contributor =
         () -> Mono.just(Map.of("connectionPoolSize", 10, "latencyMs", 5));
     var indicator =
-        new ReactiveFeatureFlagHealthIndicator(
-            provider, properties, null, List.of(contributor));
+        new ReactiveFeatureFlagHealthIndicator(provider, properties, null, List.of(contributor));
 
     Health health = indicator.health().block();
 

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicatorTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicatorTest.java
@@ -3,6 +3,7 @@ package net.brightroom.featureflag.actuator.health;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.Map;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveFeatureFlagProvider;
@@ -26,7 +27,7 @@ class ReactiveFeatureFlagHealthIndicatorTest {
         new MutableInMemoryReactiveFeatureFlagProvider(
             Map.of("feature-a", true, "feature-b", false), false);
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties);
+    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health().block();
 
@@ -45,7 +46,7 @@ class ReactiveFeatureFlagHealthIndicatorTest {
         featureName -> Mono.just("feature-a".equals(featureName));
     when(properties.featureNames()).thenReturn(Map.of("feature-a", true, "feature-b", false));
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties);
+    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health().block();
 
@@ -61,7 +62,7 @@ class ReactiveFeatureFlagHealthIndicatorTest {
     ReactiveFeatureFlagProvider provider =
         featureName -> Mono.error(new RuntimeException("Connection refused"));
     when(properties.featureNames()).thenReturn(Map.of("feature-a", true));
-    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties);
+    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health().block();
 
@@ -73,7 +74,7 @@ class ReactiveFeatureFlagHealthIndicatorTest {
   void health_isUp_withNoFlags() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties);
+    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health().block();
 
@@ -88,7 +89,7 @@ class ReactiveFeatureFlagHealthIndicatorTest {
   void health_reflectsDefaultEnabled_true() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), true);
     when(properties.defaultEnabled()).thenReturn(true);
-    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties);
+    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health().block();
 
@@ -99,11 +100,37 @@ class ReactiveFeatureFlagHealthIndicatorTest {
   void health_includesProviderClassName() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
     when(properties.defaultEnabled()).thenReturn(false);
-    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties);
+    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties, null);
 
     Health health = indicator.health().block();
 
     assertThat(health.getDetails())
         .containsEntry("provider", "MutableInMemoryReactiveFeatureFlagProvider");
+  }
+
+  @Test
+  void health_isDown_whenProviderExceedsTimeout() {
+    ReactiveFeatureFlagProvider provider =
+        featureName -> Mono.just(true).delayElement(Duration.ofSeconds(5));
+    when(properties.featureNames()).thenReturn(Map.of("feature-a", true));
+    var indicator =
+        new ReactiveFeatureFlagHealthIndicator(provider, properties, Duration.ofMillis(100));
+
+    Health health = indicator.health().block();
+
+    assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(health.getDetails()).containsKey("error");
+  }
+
+  @Test
+  void health_isUp_whenProviderRespondsWithinTimeout() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    var indicator =
+        new ReactiveFeatureFlagHealthIndicator(provider, properties, Duration.ofSeconds(5));
+
+    Health health = indicator.health().block();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
   }
 }


### PR DESCRIPTION
Closes #177

## Summary

Adds `management.health.feature-flag.timeout` property to configure the maximum time the health indicator will wait for the feature flag provider. When the provider exceeds the timeout, the health status is reported as DOWN instead of blocking indefinitely.

## Changes

- Add `FeatureFlagHealthProperties` with `timeout` field (Duration, nullable)
- Update `FeatureFlagHealthIndicator` to apply timeout via CompletableFuture
- Update `ReactiveFeatureFlagHealthIndicator` to apply timeout via Reactor `.timeout()`
- Wire `FeatureFlagHealthProperties` in `FeatureFlagActuatorAutoConfiguration`
- Add timeout unit tests for both sync and reactive indicators

Generated with [Claude Code](https://claude.ai/code)