### PR TITLE
Close #176: feat(actuator): add HealthDetailsContributor SPI for custom provider health details

### DIFF
--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
@@ -1,9 +1,12 @@
 package net.brightroom.featureflag.actuator.autoconfigure;
 
+import java.util.List;
 import net.brightroom.featureflag.actuator.endpoint.FeatureFlagEndpoint;
 import net.brightroom.featureflag.actuator.endpoint.ReactiveFeatureFlagEndpoint;
 import net.brightroom.featureflag.actuator.health.FeatureFlagHealthIndicator;
+import net.brightroom.featureflag.actuator.health.HealthDetailsContributor;
 import net.brightroom.featureflag.actuator.health.ReactiveFeatureFlagHealthIndicator;
+import net.brightroom.featureflag.actuator.health.ReactiveHealthDetailsContributor;
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -93,12 +96,14 @@ public class FeatureFlagActuatorAutoConfiguration {
      * indicator is enabled.
      *
      * @param provider the feature flag provider
+     * @param contributors the list of {@link HealthDetailsContributor} beans; may be empty
      * @return the feature flag health indicator
      */
     @Bean
     @ConditionalOnEnabledHealthIndicator("featureFlag")
-    FeatureFlagHealthIndicator featureFlagHealthIndicator(FeatureFlagProvider provider) {
-      return new FeatureFlagHealthIndicator(provider, featureFlagProperties);
+    FeatureFlagHealthIndicator featureFlagHealthIndicator(
+        FeatureFlagProvider provider, List<HealthDetailsContributor> contributors) {
+      return new FeatureFlagHealthIndicator(provider, featureFlagProperties, contributors);
     }
 
     /**
@@ -164,13 +169,14 @@ public class FeatureFlagActuatorAutoConfiguration {
      * health indicator is enabled.
      *
      * @param provider the reactive feature flag provider
+     * @param contributors the list of {@link ReactiveHealthDetailsContributor} beans; may be empty
      * @return the reactive feature flag health indicator
      */
     @Bean
     @ConditionalOnEnabledHealthIndicator("featureFlag")
     ReactiveFeatureFlagHealthIndicator featureFlagHealthIndicator(
-        ReactiveFeatureFlagProvider provider) {
-      return new ReactiveFeatureFlagHealthIndicator(provider, featureFlagProperties);
+        ReactiveFeatureFlagProvider provider, List<ReactiveHealthDetailsContributor> contributors) {
+      return new ReactiveFeatureFlagHealthIndicator(provider, featureFlagProperties, contributors);
     }
 
     /**

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicator.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicator.java
@@ -1,6 +1,7 @@
 package net.brightroom.featureflag.actuator.health;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -31,11 +32,14 @@ import org.springframework.boot.health.contributor.Health;
  * via {@link MutableFeatureFlagProvider#getFeatures()}. Otherwise, the configured feature names
  * from {@link FeatureFlagProperties} are probed individually via {@link
  * FeatureFlagProvider#isFeatureEnabled(String)}.
+ *
+ * <p>Additional details can be contributed by registering {@link HealthDetailsContributor} beans.
  */
 public class FeatureFlagHealthIndicator extends AbstractHealthIndicator {
 
   private final FeatureFlagProvider provider;
   private final FeatureFlagProperties properties;
+  private final List<HealthDetailsContributor> contributors;
 
   /**
    * Creates a new {@link FeatureFlagHealthIndicator}.
@@ -45,9 +49,24 @@ public class FeatureFlagHealthIndicator extends AbstractHealthIndicator {
    */
   public FeatureFlagHealthIndicator(
       FeatureFlagProvider provider, FeatureFlagProperties properties) {
+    this(provider, properties, List.of());
+  }
+
+  /**
+   * Creates a new {@link FeatureFlagHealthIndicator} with custom detail contributors.
+   *
+   * @param provider the feature flag provider to check
+   * @param properties the feature flag configuration properties
+   * @param contributors the list of contributors that add custom details to the health response
+   */
+  public FeatureFlagHealthIndicator(
+      FeatureFlagProvider provider,
+      FeatureFlagProperties properties,
+      List<HealthDetailsContributor> contributors) {
     super("Feature flag health check failed");
     this.provider = provider;
     this.properties = properties;
+    this.contributors = contributors;
   }
 
   @Override
@@ -74,5 +93,9 @@ public class FeatureFlagHealthIndicator extends AbstractHealthIndicator {
         .withDetail("enabledFlags", enabledCount)
         .withDetail("disabledFlags", disabledCount)
         .withDetail("defaultEnabled", properties.defaultEnabled());
+
+    for (HealthDetailsContributor contributor : contributors) {
+      contributor.contributeDetails().forEach(builder::withDetail);
+    }
   }
 }

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/HealthDetailsContributor.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/HealthDetailsContributor.java
@@ -1,0 +1,37 @@
+package net.brightroom.featureflag.actuator.health;
+
+import java.util.Map;
+
+/**
+ * SPI for contributing additional details to the {@link FeatureFlagHealthIndicator}.
+ *
+ * <p>Implement this interface and register the implementation as a Spring bean to include custom
+ * details in the {@code featureFlag} health indicator response. This is useful for custom providers
+ * (e.g., DB- or Redis-backed) that want to expose additional information such as connection pool
+ * status or latency.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * @Component
+ * public class MyProviderHealthDetailsContributor implements HealthDetailsContributor {
+ *
+ *   @Override
+ *   public Map<String, Object> contributeDetails() {
+ *     return Map.of("connectionPoolSize", 10, "latencyMs", 5);
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>All registered contributors are called during the health check, and their returned details are
+ * merged into the health response. If two contributors return the same key, the last one wins.
+ */
+public interface HealthDetailsContributor {
+
+  /**
+   * Returns a map of additional details to include in the health response.
+   *
+   * @return a non-null map of detail key-value pairs; may be empty
+   */
+  Map<String, Object> contributeDetails();
+}

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicator.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicator.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.actuator.health;
 
+import java.util.List;
 import java.util.Map;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
@@ -32,11 +33,15 @@ import reactor.core.publisher.Mono;
  * retrieved via {@link MutableReactiveFeatureFlagProvider#getFeatures()}. Otherwise, the configured
  * feature names from {@link FeatureFlagProperties} are probed individually via {@link
  * ReactiveFeatureFlagProvider#isFeatureEnabled(String)}.
+ *
+ * <p>Additional details can be contributed by registering {@link ReactiveHealthDetailsContributor}
+ * beans.
  */
 public class ReactiveFeatureFlagHealthIndicator extends AbstractReactiveHealthIndicator {
 
   private final ReactiveFeatureFlagProvider provider;
   private final FeatureFlagProperties properties;
+  private final List<ReactiveHealthDetailsContributor> contributors;
 
   /**
    * Creates a new {@link ReactiveFeatureFlagHealthIndicator}.
@@ -46,9 +51,24 @@ public class ReactiveFeatureFlagHealthIndicator extends AbstractReactiveHealthIn
    */
   public ReactiveFeatureFlagHealthIndicator(
       ReactiveFeatureFlagProvider provider, FeatureFlagProperties properties) {
+    this(provider, properties, List.of());
+  }
+
+  /**
+   * Creates a new {@link ReactiveFeatureFlagHealthIndicator} with custom detail contributors.
+   *
+   * @param provider the reactive feature flag provider to check
+   * @param properties the feature flag configuration properties
+   * @param contributors the list of contributors that add custom details to the health response
+   */
+  public ReactiveFeatureFlagHealthIndicator(
+      ReactiveFeatureFlagProvider provider,
+      FeatureFlagProperties properties,
+      List<ReactiveHealthDetailsContributor> contributors) {
     super("Feature flag health check failed");
     this.provider = provider;
     this.properties = properties;
+    this.contributors = contributors;
   }
 
   @Override
@@ -64,20 +84,24 @@ public class ReactiveFeatureFlagHealthIndicator extends AbstractReactiveHealthIn
               .collectMap(Map.Entry::getKey, Map.Entry::getValue);
     }
 
-    return featuresMono.map(
+    return featuresMono.flatMap(
         features -> {
           long totalCount = features.size();
           long enabledCount = features.values().stream().filter(Boolean::booleanValue).count();
           long disabledCount = totalCount - enabledCount;
 
-          return builder
+          builder
               .up()
               .withDetail("provider", provider.getClass().getSimpleName())
               .withDetail("totalFlags", totalCount)
               .withDetail("enabledFlags", enabledCount)
               .withDetail("disabledFlags", disabledCount)
-              .withDetail("defaultEnabled", properties.defaultEnabled())
-              .build();
+              .withDetail("defaultEnabled", properties.defaultEnabled());
+
+          return Flux.fromIterable(contributors)
+              .flatMap(ReactiveHealthDetailsContributor::contributeDetails)
+              .doOnNext(details -> details.forEach(builder::withDetail))
+              .then(Mono.fromCallable(builder::build));
         });
   }
 }

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveHealthDetailsContributor.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/health/ReactiveHealthDetailsContributor.java
@@ -1,0 +1,39 @@
+package net.brightroom.featureflag.actuator.health;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for contributing additional details to the {@link
+ * ReactiveFeatureFlagHealthIndicator}.
+ *
+ * <p>Implement this interface and register the implementation as a Spring bean to include custom
+ * details in the {@code featureFlag} health indicator response for reactive applications. This is
+ * useful for custom providers (e.g., DB- or Redis-backed) that want to expose additional
+ * information such as connection pool status or latency.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * @Component
+ * public class MyProviderReactiveHealthDetailsContributor implements ReactiveHealthDetailsContributor {
+ *
+ *   @Override
+ *   public Mono<Map<String, Object>> contributeDetails() {
+ *     return Mono.just(Map.of("connectionPoolSize", 10, "latencyMs", 5));
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>All registered contributors are called during the health check, and their returned details are
+ * merged into the health response. If two contributors return the same key, the last one wins.
+ */
+public interface ReactiveHealthDetailsContributor {
+
+  /**
+   * Returns a {@link Mono} emitting a map of additional details to include in the health response.
+   *
+   * @return a {@link Mono} emitting a non-null map of detail key-value pairs; may be empty
+   */
+  Mono<Map<String, Object>> contributeDetails();
+}

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfigurationTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfigurationTest.java
@@ -8,7 +8,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import net.brightroom.featureflag.actuator.endpoint.FeatureFlagEndpoint;
 import net.brightroom.featureflag.actuator.endpoint.ReactiveFeatureFlagEndpoint;
 import net.brightroom.featureflag.actuator.health.FeatureFlagHealthIndicator;
+import net.brightroom.featureflag.actuator.health.HealthDetailsContributor;
 import net.brightroom.featureflag.actuator.health.ReactiveFeatureFlagHealthIndicator;
+import net.brightroom.featureflag.actuator.health.ReactiveHealthDetailsContributor;
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.InMemoryFeatureFlagProvider;
@@ -26,6 +28,7 @@ import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import reactor.core.publisher.Mono;
@@ -106,6 +109,18 @@ class FeatureFlagActuatorAutoConfigurationTest {
           .run(
               context -> {
                 assertThat(context).hasSingleBean(FeatureFlagHealthIndicator.class);
+              });
+    }
+
+    @Test
+    void healthIndicator_includesContributorDetails_whenContributorBeanPresent() {
+      contextRunner
+          .withBean(HealthDetailsContributor.class, () -> () -> Map.of("custom", "value"))
+          .run(
+              context -> {
+                var indicator = context.getBean(FeatureFlagHealthIndicator.class);
+                Health health = indicator.health();
+                assertThat(health.getDetails()).containsEntry("custom", "value");
               });
     }
 
@@ -197,6 +212,20 @@ class FeatureFlagActuatorAutoConfigurationTest {
           .run(
               context -> {
                 assertThat(context).hasSingleBean(ReactiveFeatureFlagHealthIndicator.class);
+              });
+    }
+
+    @Test
+    void reactiveHealthIndicator_includesContributorDetails_whenContributorBeanPresent() {
+      contextRunner
+          .withBean(
+              ReactiveHealthDetailsContributor.class,
+              () -> () -> Mono.just(Map.of("custom", "value")))
+          .run(
+              context -> {
+                var indicator = context.getBean(ReactiveFeatureFlagHealthIndicator.class);
+                Health health = indicator.health().block();
+                assertThat(health.getDetails()).containsEntry("custom", "value");
               });
     }
 

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicatorTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/health/FeatureFlagHealthIndicatorTest.java
@@ -3,6 +3,7 @@ package net.brightroom.featureflag.actuator.health;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -104,5 +105,47 @@ class FeatureFlagHealthIndicatorTest {
     Health health = indicator.health();
 
     assertThat(health.getDetails()).containsEntry("provider", "MutableInMemoryFeatureFlagProvider");
+  }
+
+  @Test
+  void health_includesContributorDetails() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    HealthDetailsContributor contributor = () -> Map.of("connectionPoolSize", 10, "latencyMs", 5);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, List.of(contributor));
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails())
+        .containsEntry("connectionPoolSize", 10)
+        .containsEntry("latencyMs", 5);
+  }
+
+  @Test
+  void health_mergesMultipleContributorDetails() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    HealthDetailsContributor contributor1 = () -> Map.of("key1", "value1");
+    HealthDetailsContributor contributor2 = () -> Map.of("key2", "value2");
+    var indicator =
+        new FeatureFlagHealthIndicator(provider, properties, List.of(contributor1, contributor2));
+
+    Health health = indicator.health();
+
+    assertThat(health.getDetails()).containsEntry("key1", "value1").containsEntry("key2", "value2");
+  }
+
+  @Test
+  void health_withNoContributors_hasDefaultDetails() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    var indicator = new FeatureFlagHealthIndicator(provider, properties, List.of());
+
+    Health health = indicator.health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails())
+        .containsKeys("provider", "totalFlags", "enabledFlags", "disabledFlags", "defaultEnabled");
   }
 }

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicatorTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/health/ReactiveFeatureFlagHealthIndicatorTest.java
@@ -3,6 +3,7 @@ package net.brightroom.featureflag.actuator.health;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveFeatureFlagProvider;
@@ -105,5 +106,50 @@ class ReactiveFeatureFlagHealthIndicatorTest {
 
     assertThat(health.getDetails())
         .containsEntry("provider", "MutableInMemoryReactiveFeatureFlagProvider");
+  }
+
+  @Test
+  void health_includesContributorDetails() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    ReactiveHealthDetailsContributor contributor =
+        () -> Mono.just(Map.of("connectionPoolSize", 10, "latencyMs", 5));
+    var indicator =
+        new ReactiveFeatureFlagHealthIndicator(provider, properties, List.of(contributor));
+
+    Health health = indicator.health().block();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails())
+        .containsEntry("connectionPoolSize", 10)
+        .containsEntry("latencyMs", 5);
+  }
+
+  @Test
+  void health_mergesMultipleContributorDetails() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    ReactiveHealthDetailsContributor contributor1 = () -> Mono.just(Map.of("key1", "value1"));
+    ReactiveHealthDetailsContributor contributor2 = () -> Mono.just(Map.of("key2", "value2"));
+    var indicator =
+        new ReactiveFeatureFlagHealthIndicator(
+            provider, properties, List.of(contributor1, contributor2));
+
+    Health health = indicator.health().block();
+
+    assertThat(health.getDetails()).containsEntry("key1", "value1").containsEntry("key2", "value2");
+  }
+
+  @Test
+  void health_withNoContributors_hasDefaultDetails() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
+    when(properties.defaultEnabled()).thenReturn(false);
+    var indicator = new ReactiveFeatureFlagHealthIndicator(provider, properties, List.of());
+
+    Health health = indicator.health().block();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UP);
+    assertThat(health.getDetails())
+        .containsKeys("provider", "totalFlags", "enabledFlags", "disabledFlags", "defaultEnabled");
   }
 }


### PR DESCRIPTION
Close #176

## Summary

Adds `HealthDetailsContributor` and `ReactiveHealthDetailsContributor` SPI interfaces to allow custom providers (DB/Redis-based etc.) to contribute arbitrary key-value details to the `featureFlag` health indicator response.

- `FeatureFlagHealthIndicator` now accepts a `List<HealthDetailsContributor>`
- `ReactiveFeatureFlagHealthIndicator` now accepts a `List<ReactiveHealthDetailsContributor>`
- Auto-configuration injects all contributor beans automatically via Spring list injection
- Both indicators retain a no-contributors constructor for backward compatibility

Generated with [Claude Code](https://claude.ai/code)