### PR TITLE
Close #178: feat(core): add configuration metadata for feature-flags.features sub-properties

### DIFF
--- a/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -24,6 +24,18 @@
       "description": "Per-feature configuration including enabled state and rollout percentage."
     },
     {
+      "name": "feature-flags.features.[*].enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether this feature flag is enabled.",
+      "defaultValue": true
+    },
+    {
+      "name": "feature-flags.features.[*].rollout",
+      "type": "java.lang.Integer",
+      "description": "Rollout percentage for this feature flag (0-100). 100 means fully rolled out to all requests; 0 means no requests even if enabled.",
+      "defaultValue": 100
+    },
+    {
       "name": "feature-flags.response.type",
       "type": "net.brightroom.featureflag.core.properties.ResponseType",
       "description": "The type of response to return."


### PR DESCRIPTION
Close #178

## Summary

Add `additional-spring-configuration-metadata.json` entries for `feature-flags.features.[*].enabled` and `feature-flags.features.[*].rollout` to enable IDE autocompletion and validation for `FeatureConfiguration` nested properties.

Generated with [Claude Code](https://claude.ai/code)