### PR TITLE
perf: enable parallel test execution with maxParallelForks

### DIFF
--- a/gradle-scripts/src/main/kotlin/integration-test.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/integration-test.gradle.kts
@@ -26,6 +26,7 @@ tasks {
             classpath = sourceSets["integrationTest"].runtimeClasspath
             useJUnitPlatform()
             shouldRunAfter(test)
+            maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
         }
 
     check {

--- a/gradle-scripts/src/main/kotlin/spring-boot-starter.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/spring-boot-starter.gradle.kts
@@ -33,5 +33,6 @@ tasks {
 
     test {
         useJUnitPlatform()
+        maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     }
 }


### PR DESCRIPTION
## Summary

- unit test / integration test の `maxParallelForks` を `availableProcessors / 2`（最小1）に設定
  - `spring-boot-starter.gradle.kts`: unit test タスクに適用
  - `integration-test.gradle.kts`: integration test タスクに適用
- 全 integration test が `RANDOM_PORT` を使用していることを確認済みのため、並列実行で安全

## 備考

- CI (ubuntu-latest: 2 vCPU) では `maxParallelForks = 1` となるため CI 上での効果は限定的
- ローカル開発環境（マルチコア）での恩恵が主

## Test plan

- [x] ローカルで `./gradlew check` が成功することを確認済み
- [ ] CI 上で全テストが安定して Pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)