### PR TITLE
ci: add seed-gradle-cache workflow for main branch

### DIFF
--- a/.github/workflows/seed-gradle-cache.yaml
+++ b/.github/workflows/seed-gradle-cache.yaml
@@ -1,0 +1,19 @@
+name: seed-gradle-cache
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  seed-cache:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Build
+        uses: ./.github/actions/gradle-action
+        with:
+          command: classes testClasses


### PR DESCRIPTION
## Summary

- `seed-gradle-cache.yaml` を新規作成
  - main への push 時に `classes testClasses` を実行し、Gradle キャッシュを保存
  - `setup-gradle` はデフォルトブランチでは `cache-read-only: false` のため、キャッシュが保存される
- 以降の PR 実行で依存関係・Gradle wrapper のキャッシュが復元され、セットアップ時間が短縮される

## 背景

`setup-gradle` は PR ブランチで `cache-read-only: true` がデフォルトのため、PR ジョブではキャッシュが保存されない。main ブランチでの実行がなかったため、キャッシュが一度も保存されず全ジョブでゼロからダウンロードが発生していた。

## Test plan

- [ ] この PR を main にマージ後、`seed-gradle-cache` ワークフローが発火しキャッシュが保存されること
- [ ] その後の PR で `Gradle User Home cache` が復元されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)