### PR TITLE
Fix code review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ When the provider responds normally, the component reports `UP` with flag statis
     "featureFlag": {
       "status": "UP",
       "details": {
-        "provider": "InMemoryFeatureFlagProvider",
+        "provider": "MutableInMemoryFeatureFlagProvider",
         "totalFlags": 2,
         "enabledFlags": 1,
         "disabledFlags": 1,

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.actuator.endpoint;
 
+import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
 import net.brightroom.featureflag.core.provider.MutableFeatureFlagProvider;
@@ -54,6 +55,9 @@ public class FeatureFlagEndpoint {
    */
   @ReadOperation
   public FeatureFlagEndpointResponse feature(@Selector String featureName) {
+    if (featureName == null || featureName.isBlank()) {
+      throw new IllegalArgumentException("featureName must not be null or blank");
+    }
     return new FeatureFlagEndpointResponse(
         featureName,
         provider.isFeatureEnabled(featureName),
@@ -117,6 +121,7 @@ public class FeatureFlagEndpoint {
     var rolloutPercentages = rolloutProvider.getRolloutPercentages();
     var featureList =
         provider.getFeatures().entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
             .map(
                 e ->
                     new FeatureFlagEndpointResponse(

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
@@ -57,6 +57,9 @@ public class ReactiveFeatureFlagEndpoint {
    */
   @ReadOperation
   public FeatureFlagEndpointResponse feature(@Selector String featureName) {
+    if (featureName == null || featureName.isBlank()) {
+      throw new IllegalArgumentException("featureName must not be null or blank");
+    }
     var enabled = provider.isFeatureEnabled(featureName).block();
     var rollout = rolloutProvider.getRolloutPercentage(featureName).blockOptional().orElse(100);
     return new FeatureFlagEndpointResponse(featureName, Boolean.TRUE.equals(enabled), rollout);
@@ -124,6 +127,7 @@ public class ReactiveFeatureFlagEndpoint {
         rolloutProvider.getRolloutPercentages().blockOptional().orElse(Map.of());
     var featureList =
         features.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
             .map(
                 e ->
                     new FeatureFlagEndpointResponse(

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
@@ -56,6 +56,7 @@ public class FeatureFlagWebFluxAutoConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean
   AccessDeniedExceptionHandlerResolution accessDeniedExceptionHandlerResolution() {
     return new AccessDeniedExceptionHandlerResolutionFactory().create(featureFlagProperties);
   }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -45,9 +45,9 @@ public class FeatureFlagHandlerFilterFunction {
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
    *
-   * @param featureName the name of the feature flag to check; must not be null or empty
+   * @param featureName the name of the feature flag to check; must not be null or blank
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
-   * @throws IllegalArgumentException if {@code featureName} is null or empty
+   * @throws IllegalArgumentException if {@code featureName} is null or blank
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(String featureName) {
     return of(featureName, 100);
@@ -61,20 +61,20 @@ public class FeatureFlagHandlerFilterFunction {
    * If no rollout percentage is configured in the provider, the {@code rolloutFallback} argument is
    * used as a fallback.
    *
-   * @param featureName the name of the feature flag to check; must not be null or empty
+   * @param featureName the name of the feature flag to check; must not be null or blank
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
    *     the provider; 100 means fully enabled
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
    *     and rollout
-   * @throws IllegalArgumentException if {@code featureName} is null or empty, or if {@code
+   * @throws IllegalArgumentException if {@code featureName} is null or blank, or if {@code
    *     rolloutFallback} is not between 0 and 100
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
       String featureName, int rolloutFallback) {
-    if (featureName == null || featureName.isEmpty()) {
+    if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException(
-          "featureName must not be null or empty. "
-              + "An empty value causes fail-open behavior and allows access unconditionally.");
+          "featureName must not be null or blank. "
+              + "A blank value causes fail-open behavior and allows access unconditionally.");
     }
     if (rolloutFallback < 0 || rolloutFallback > 100) {
       throw new IllegalArgumentException(

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -53,14 +53,14 @@ class FeatureFlagHandlerFilterFunctionTest {
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {
     assertThatThrownBy(() -> filterFunction.of(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("null or empty");
+        .hasMessageContaining("null or blank");
   }
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsEmpty() {
     assertThatThrownBy(() -> filterFunction.of(""))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("null or empty");
+        .hasMessageContaining("null or blank");
   }
 
   @Test

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -46,9 +46,9 @@ public class FeatureFlagHandlerFilterFunction {
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
    *
-   * @param featureName the name of the feature flag to check; must not be null or empty
+   * @param featureName the name of the feature flag to check; must not be null or blank
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
-   * @throws IllegalArgumentException if {@code featureName} is null or empty
+   * @throws IllegalArgumentException if {@code featureName} is null or blank
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(String featureName) {
     return of(featureName, 100);
@@ -62,20 +62,20 @@ public class FeatureFlagHandlerFilterFunction {
    * rollout percentage is configured in the provider, the {@code rolloutFallback} argument is used
    * as a fallback.
    *
-   * @param featureName the name of the feature flag to check; must not be null or empty
+   * @param featureName the name of the feature flag to check; must not be null or blank
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
    *     the provider; 100 means fully enabled
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
    *     and rollout
-   * @throws IllegalArgumentException if {@code featureName} is null or empty, or if {@code
+   * @throws IllegalArgumentException if {@code featureName} is null or blank, or if {@code
    *     rolloutFallback} is not between 0 and 100
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
       String featureName, int rolloutFallback) {
-    if (featureName == null || featureName.isEmpty()) {
+    if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException(
-          "featureName must not be null or empty. "
-              + "An empty value causes fail-open behavior and allows access unconditionally.");
+          "featureName must not be null or blank. "
+              + "A blank value causes fail-open behavior and allows access unconditionally.");
     }
     if (rolloutFallback < 0 || rolloutFallback > 100) {
       throw new IllegalArgumentException(

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -52,14 +52,14 @@ class FeatureFlagHandlerFilterFunctionTest {
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {
     assertThatThrownBy(() -> filterFunction.of(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("null or empty");
+        .hasMessageContaining("null or blank");
   }
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsEmpty() {
     assertThatThrownBy(() -> filterFunction.of(""))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("null or empty");
+        .hasMessageContaining("null or blank");
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **M-1**: Add `@ConditionalOnMissingBean` to WebFlux `AccessDeniedExceptionHandlerResolution` bean definition for consistency with webmvc and handler filter
- **M-2**: Add input validation to `feature()` read operation in `FeatureFlagEndpoint` and `ReactiveFeatureFlagEndpoint` to match `updateFeature()`/`deleteFeature()`
- **L-1**: Sort feature list by `featureName` in actuator endpoint responses for deterministic ordering
- **L-2**: Unify `featureName` validation to use `isBlank()` instead of `isEmpty()` in `HandlerFilterFunction.of()` (both webmvc and webflux)
- **L-3**: Fix README health indicator example provider name from `InMemoryFeatureFlagProvider` to `MutableInMemoryFeatureFlagProvider`

## Test plan

- [x] `./gradlew check` passes (Spotless + unit tests + integration tests across all modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)