### PR TITLE
fix: resolve publishToMavenLocal build failures

### DIFF
--- a/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import util.by
 
 plugins {
@@ -63,6 +64,10 @@ publishing {
 }
 
 tasks {
+    withType<GenerateMavenPom>().configureEach {
+        notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/24329")
+    }
+
     sonatypeCentralUpload {
         dependsOn("jar", "sourcesJar", "javadocJar", "generatePomFileForMavenJavaPublication")
 

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/AccessDeniedInterceptResolutionFactory.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/AccessDeniedInterceptResolutionFactory.java
@@ -8,7 +8,7 @@ import net.brightroom.featureflag.core.properties.ResponseProperties;
  * response type.
  *
  * <p>Selects the appropriate resolution implementation from {@link
- * net.brightroom.featureflag.core.properties.ResponseProperties.ResponseType} configured via {@code
+ * net.brightroom.featureflag.core.properties.ResponseType ResponseType} configured via {@code
  * feature-flags.response.type}.
  */
 public class AccessDeniedInterceptResolutionFactory {

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
@@ -8,7 +8,7 @@ import net.brightroom.featureflag.core.properties.ResponseProperties;
  * configured response type.
  *
  * <p>Selects the appropriate resolution implementation from {@link
- * net.brightroom.featureflag.core.properties.ResponseProperties.ResponseType} configured via {@code
+ * net.brightroom.featureflag.core.properties.ResponseType ResponseType} configured via {@code
  * feature-flags.response.type}.
  */
 public class AccessDeniedHandlerFilterResolutionFactory {


### PR DESCRIPTION
## Summary
- Fix invalid Javadoc `{@link}` references to non-existent `ResponseProperties.ResponseType` (correctly references top-level `ResponseType`)
- Mark `GenerateMavenPom` tasks as not compatible with configuration cache to work around [gradle/gradle#24329](https://github.com/gradle/gradle/issues/24329)

## Test plan
- [x] `./gradlew publishToMavenLocal` completes with `BUILD SUCCESSFUL`
- [x] `./gradlew :webmvc:javadoc` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)