### PR TITLE
fix: disable configuration cache for deploy workflow

### DIFF
--- a/.github/workflows/on-deploy.yaml
+++ b/.github/workflows/on-deploy.yaml
@@ -23,4 +23,4 @@ jobs:
           PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
           PGP_SIGNING_KEY_PASSPHRASE: ${{ secrets.PGP_SIGNING_KEY_PASSPHRASE }}
         with:
-          command: sonatypeCentralUpload -PreleaseVersion=${{ github.event.release.tag_name }}
+          command: sonatypeCentralUpload -PreleaseVersion=${{ github.event.release.tag_name }} --no-configuration-cache

--- a/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import util.by
 
 plugins {
@@ -64,10 +63,6 @@ publishing {
 }
 
 tasks {
-    withType<GenerateMavenPom>().configureEach {
-        notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/24329")
-    }
-
     sonatypeCentralUpload {
         dependsOn("jar", "sourcesJar", "javadocJar", "generatePomFileForMavenJavaPublication")
 


### PR DESCRIPTION
## Summary
- `sonatypeCentralUpload` タスクが `TaskCollection#all(Action)` を使用しており、Gradle の Configuration Cache と非互換であるためデプロイが失敗していた
- デプロイワークフローに `--no-configuration-cache` を追加して Configuration Cache を無効化
- 不要になった `GenerateMavenPom` の `notCompatibleWithConfigurationCache` 宣言を削除

## Test plan
- [ ] リリースを作成してデプロイワークフローが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)