### PR TITLE
fix: replace TaskCollection#all with string-based task dependencies

### DIFF
--- a/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
@@ -70,9 +70,7 @@ tasks {
         // preventing partial uploads when a sibling module's javadoc fails.
         rootProject.subprojects.forEach { sub ->
             if (sub != project) {
-                sub.tasks.matching { it.name == "javadocJar" }.all {
-                    this@sonatypeCentralUpload.dependsOn(this)
-                }
+                dependsOn("${sub.path}:javadocJar")
             }
         }
 


### PR DESCRIPTION
## Summary
- `sonatypeCentralUpload` タスク内の `sub.tasks.matching { }.all { }` が Gradle のクロスプロジェクトタスク解決制限に抵触してビルドが失敗していた
- 文字列ベースのタスクパス依存 (`dependsOn("${sub.path}:javadocJar")`) に置き換え、タスクコレクションの即時解決を回避

## Test plan
- [ ] リリースを作成してデプロイワークフローが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)