### PR TITLE
Close #125 feat: add SpEL condition support to @FeatureFlag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,15 @@ This is a multi-module Gradle project (Java 25, Spring Boot 4.x) that provides f
 1. `FeatureFlagMvcInterceptorRegistrationAutoConfiguration` registers `FeatureFlagInterceptor` for all paths (`/**`).
 2. `FeatureFlagInterceptor.preHandle()` checks `@FeatureFlag` on the method first, then on the class. Method-level annotation takes priority.
 3. If the feature is disabled, `FeatureFlagAccessDeniedException` is thrown.
-4. `FeatureFlagExceptionHandler` (`@ControllerAdvice`, `@Order(Ordered.LOWEST_PRECEDENCE)`) catches the exception and delegates to `AccessDeniedInterceptResolution.resolution()` to write the response.
+4. If `condition` is non-empty, the SpEL expression is evaluated against request context variables (`headers`, `params`, `cookies`, `path`, `method`, `remoteAddress`). If the condition is not satisfied, `FeatureFlagAccessDeniedException` is thrown.
+5. If `rollout < 100`, the rollout percentage check is performed.
+6. `FeatureFlagExceptionHandler` (`@ControllerAdvice`, `@Order(Ordered.LOWEST_PRECEDENCE)`) catches the exception and delegates to `AccessDeniedInterceptResolution.resolution()` to write the response.
 
 ### Extension Points
 
 - **Custom feature source**: Implement `FeatureFlagProvider` (webmvc) or `ReactiveFeatureFlagProvider` (webflux) and register as a `@Bean`. The default `InMemoryFeatureFlagProvider` / `InMemoryReactiveFeatureFlagProvider` reads from `feature-flags.feature-names` in config and is **fail-closed by default** — feature names not present in the config are treated as disabled. Set `feature-flags.default-enabled: true` to switch to fail-open behavior. A custom bean replaces the default due to `@ConditionalOnMissingBean`.
 - **Custom denied response**: Define a `@ControllerAdvice` that handles `FeatureFlagAccessDeniedException`. It takes priority over the library's default handler.
+- **Conditional access**: Use `@FeatureFlag(value = "name", condition = "headers['X-Beta'] != null")` to enable a feature only when a SpEL condition evaluated against request context is satisfied. Implement `FeatureFlagConditionEvaluator` (webmvc) or `ReactiveFeatureFlagConditionEvaluator` (webflux) to replace the default SpEL evaluator. The `@FeatureFlag` annotation also exposes a `condition` attribute; the `ConditionVariablesBuilder` in core centralizes the available variable key names (`headers`, `params`, `cookies`, `path`, `method`, `remoteAddress`). Configure fail-on-error behavior with `feature-flags.condition.fail-on-error`.
 - **Gradual rollout**: Use `@FeatureFlag(value = "name", rollout = 50)` to enable a feature for a percentage of requests. Implement `FeatureFlagContextResolver` (webmvc) or `ReactiveFeatureFlagContextResolver` (webflux) for sticky rollout. Implement `RolloutStrategy` (webmvc) or `ReactiveRolloutStrategy` (webflux) to customize bucketing.
 
 ### Auto-configuration Registration

--- a/README.md
+++ b/README.md
@@ -325,6 +325,99 @@ public class CustomHandlerFilterResolutionConfig {
 }
 ```
 
+## Conditional Feature Flags
+
+Use the `condition` attribute on `@FeatureFlag` to enable a feature only when a SpEL expression
+evaluated against the incoming request is satisfied.
+
+```java
+@RestController
+class BetaController {
+
+  @GetMapping("/new-feature")
+  @FeatureFlag(value = "new-feature", condition = "headers['X-Beta'] != null")
+  String newFeature() {
+    return "You're in the beta!";
+  }
+}
+```
+
+The evaluation order is: **feature enabled** → **condition** → **rollout**. If the condition is not
+satisfied, `403 Forbidden` is returned.
+
+### Available Variables
+
+| Variable | Type | Description |
+|---|---|---|
+| `headers` | `Map<String, String>` | Request headers (first value per name) |
+| `params` | `Map<String, String>` | Query parameters (first value per name) |
+| `cookies` | `Map<String, String>` | Cookie values keyed by name |
+| `path` | `String` | Request path (e.g. `/api/resource`) |
+| `method` | `String` | HTTP method (e.g. `GET`, `POST`) |
+| `remoteAddress` | `String` | Client IP address |
+
+### Configuration
+
+By default, if the SpEL expression throws an error, access is denied (fail-closed). Set
+`feature-flags.condition.fail-on-error: false` to allow access instead (fail-open).
+
+```yaml
+feature-flags:
+  condition:
+    fail-on-error: true  # true (fail-closed, default) | false (fail-open)
+```
+
+### WebFlux Functional Endpoints
+
+Pass a condition expression as the second argument to `of`:
+
+```java
+@Bean
+RouterFunction<ServerResponse> routes(FeatureFlagHandlerFilterFunction featureFlagFilter) {
+    return route()
+        .GET("/new-feature", handler::handle)
+        .filter(featureFlagFilter.of("new-feature", "headers['X-Beta'] != null"))
+        .build();
+}
+```
+
+You can also combine condition and rollout:
+
+```java
+.filter(featureFlagFilter.of("new-feature", "headers['X-Beta'] != null", 50))
+```
+
+### Custom Condition Evaluator
+
+Implement `FeatureFlagConditionEvaluator` (Spring MVC) or `ReactiveFeatureFlagConditionEvaluator`
+(Spring WebFlux) and register it as a `@Bean` to replace the default SpEL-based evaluator.
+
+```java
+// Spring MVC
+@Component
+class CustomConditionEvaluator implements FeatureFlagConditionEvaluator {
+
+  @Override
+  public boolean evaluate(String expression, Map<String, Object> variables) {
+    // custom evaluation logic
+    return true;
+  }
+}
+```
+
+```java
+// Spring WebFlux
+@Component
+class CustomReactiveConditionEvaluator implements ReactiveFeatureFlagConditionEvaluator {
+
+  @Override
+  public Mono<Boolean> evaluate(String expression, Map<String, Object> variables) {
+    // non-blocking evaluation logic
+    return Mono.just(true);
+  }
+}
+```
+
 ## Gradual Rollout
 
 Use the `rollout` attribute on `@FeatureFlag` to enable a feature for only a percentage of requests.

--- a/core/src/main/java/net/brightroom/featureflag/core/annotation/FeatureFlag.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/annotation/FeatureFlag.java
@@ -45,6 +45,28 @@ public @interface FeatureFlag {
   String value();
 
   /**
+   * SpEL condition expression evaluated against request context.
+   *
+   * <p>When non-empty, the feature is enabled only if the expression evaluates to {@code true}.
+   *
+   * <p>Available variables:
+   *
+   * <ul>
+   *   <li>{@code headers} — request headers as {@code Map<String, String>}
+   *   <li>{@code params} — query parameters as {@code Map<String, String>}
+   *   <li>{@code cookies} — cookies as {@code Map<String, String>}
+   *   <li>{@code path} — request path as {@code String}
+   *   <li>{@code method} — HTTP method as {@code String}
+   *   <li>{@code remoteAddress} — client IP as {@code String}
+   * </ul>
+   *
+   * <p>Example: {@code @FeatureFlag(value = "beta", condition = "headers['X-Beta'] != null")}
+   *
+   * @return SpEL expression; empty string (default) means no condition
+   */
+  String condition() default "";
+
+  /**
    * Rollout percentage (0–100). 100 means fully enabled (default).
    *
    * <p>When less than 100, the feature is enabled only for a percentage of requests (or users, if a

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariables.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariables.java
@@ -1,6 +1,8 @@
 package net.brightroom.featureflag.core.condition;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Immutable holder for request context variables available in SpEL condition expressions.
@@ -10,59 +12,40 @@ import java.util.Map;
  * <p>Available properties:
  *
  * <ul>
- *   <li>{@code headers} — {@code Map<String, String>} of request headers (first value per name)
+ *   <li>{@code headers} — {@code Map<String, String>} of request headers (first value per name,
+ *       case-insensitive keys)
  *   <li>{@code params} — {@code Map<String, String>} of query parameters (first value per name)
  *   <li>{@code cookies} — {@code Map<String, String>} of cookie values keyed by cookie name
  *   <li>{@code path} — {@code String} request path (e.g. {@code /api/resource})
  *   <li>{@code method} — {@code String} HTTP method (e.g. {@code GET}, {@code POST})
  *   <li>{@code remoteAddress} — {@code String} client IP address
  * </ul>
+ *
+ * @param headers request headers as {@code Map<String, String>}
+ * @param params query parameters as {@code Map<String, String>}
+ * @param cookies cookies as {@code Map<String, String>}
+ * @param path request path
+ * @param method HTTP method
+ * @param remoteAddress client IP address
  */
-public final class ConditionVariables {
+public record ConditionVariables(
+    Map<String, String> headers,
+    Map<String, String> params,
+    Map<String, String> cookies,
+    String path,
+    String method,
+    String remoteAddress) {
 
-  private final Map<String, String> headers;
-  private final Map<String, String> params;
-  private final Map<String, String> cookies;
-  private final String path;
-  private final String method;
-  private final String remoteAddress;
-
-  ConditionVariables(
-      Map<String, String> headers,
-      Map<String, String> params,
-      Map<String, String> cookies,
-      String path,
-      String method,
-      String remoteAddress) {
-    this.headers = headers;
-    this.params = params;
-    this.cookies = cookies;
-    this.path = path;
-    this.method = method;
-    this.remoteAddress = remoteAddress;
-  }
-
-  public Map<String, String> getHeaders() {
-    return headers;
-  }
-
-  public Map<String, String> getParams() {
-    return params;
-  }
-
-  public Map<String, String> getCookies() {
-    return cookies;
-  }
-
-  public String getPath() {
-    return path;
-  }
-
-  public String getMethod() {
-    return method;
-  }
-
-  public String getRemoteAddress() {
-    return remoteAddress;
+  public ConditionVariables {
+    TreeMap<String, String> headersCopy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    if (headers != null) {
+      headersCopy.putAll(headers);
+    }
+    headers = Collections.unmodifiableMap(headersCopy);
+    params = params != null ? Map.copyOf(params) : Map.of();
+    cookies = cookies != null ? Map.copyOf(cookies) : Map.of();
+    path = path != null ? path : "";
+    method = method != null ? method : "";
+    remoteAddress = remoteAddress != null ? remoteAddress : "";
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariables.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariables.java
@@ -1,0 +1,68 @@
+package net.brightroom.featureflag.core.condition;
+
+import java.util.Map;
+
+/**
+ * Immutable holder for request context variables available in SpEL condition expressions.
+ *
+ * <p>Instances are created via {@link ConditionVariablesBuilder}.
+ *
+ * <p>Available properties:
+ *
+ * <ul>
+ *   <li>{@code headers} — {@code Map<String, String>} of request headers (first value per name)
+ *   <li>{@code params} — {@code Map<String, String>} of query parameters (first value per name)
+ *   <li>{@code cookies} — {@code Map<String, String>} of cookie values keyed by cookie name
+ *   <li>{@code path} — {@code String} request path (e.g. {@code /api/resource})
+ *   <li>{@code method} — {@code String} HTTP method (e.g. {@code GET}, {@code POST})
+ *   <li>{@code remoteAddress} — {@code String} client IP address
+ * </ul>
+ */
+public final class ConditionVariables {
+
+  private final Map<String, String> headers;
+  private final Map<String, String> params;
+  private final Map<String, String> cookies;
+  private final String path;
+  private final String method;
+  private final String remoteAddress;
+
+  ConditionVariables(
+      Map<String, String> headers,
+      Map<String, String> params,
+      Map<String, String> cookies,
+      String path,
+      String method,
+      String remoteAddress) {
+    this.headers = headers;
+    this.params = params;
+    this.cookies = cookies;
+    this.path = path;
+    this.method = method;
+    this.remoteAddress = remoteAddress;
+  }
+
+  public Map<String, String> getHeaders() {
+    return headers;
+  }
+
+  public Map<String, String> getParams() {
+    return params;
+  }
+
+  public Map<String, String> getCookies() {
+    return cookies;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public String getMethod() {
+    return method;
+  }
+
+  public String getRemoteAddress() {
+    return remoteAddress;
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
@@ -1,15 +1,14 @@
 package net.brightroom.featureflag.core.condition;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Builder for constructing the variables map passed to {@link FeatureFlagConditionEvaluator} and
- * {@link ReactiveFeatureFlagConditionEvaluator}.
+ * Builder for constructing {@link ConditionVariables} passed to {@link
+ * FeatureFlagConditionEvaluator} and {@link ReactiveFeatureFlagConditionEvaluator}.
  *
  * <p>Centralizes the variable key names so that all modules ({@code webmvc}, {@code webflux}) use
  * consistent keys. Each module extracts the request-specific data and delegates to this builder to
- * construct the final map.
+ * construct the {@link ConditionVariables}.
  *
  * <p>Available variable keys:
  *
@@ -24,46 +23,51 @@ import java.util.Map;
  */
 public final class ConditionVariablesBuilder {
 
-  private final Map<String, Object> variables = new HashMap<>();
+  private Map<String, String> headers;
+  private Map<String, String> params;
+  private Map<String, String> cookies;
+  private String path;
+  private String method;
+  private String remoteAddress;
 
   /** Sets the {@code headers} variable. */
   public ConditionVariablesBuilder headers(Map<String, String> headers) {
-    variables.put("headers", headers);
+    this.headers = headers;
     return this;
   }
 
   /** Sets the {@code params} variable. */
   public ConditionVariablesBuilder params(Map<String, String> params) {
-    variables.put("params", params);
+    this.params = params;
     return this;
   }
 
   /** Sets the {@code cookies} variable. */
   public ConditionVariablesBuilder cookies(Map<String, String> cookies) {
-    variables.put("cookies", cookies);
+    this.cookies = cookies;
     return this;
   }
 
   /** Sets the {@code path} variable. */
   public ConditionVariablesBuilder path(String path) {
-    variables.put("path", path);
+    this.path = path;
     return this;
   }
 
   /** Sets the {@code method} variable. */
   public ConditionVariablesBuilder method(String method) {
-    variables.put("method", method);
+    this.method = method;
     return this;
   }
 
   /** Sets the {@code remoteAddress} variable. */
   public ConditionVariablesBuilder remoteAddress(String remoteAddress) {
-    variables.put("remoteAddress", remoteAddress);
+    this.remoteAddress = remoteAddress;
     return this;
   }
 
-  /** Returns the built variables map. */
-  public Map<String, Object> build() {
-    return Map.copyOf(variables);
+  /** Returns the built {@link ConditionVariables}. */
+  public ConditionVariables build() {
+    return new ConditionVariables(headers, params, cookies, path, method, remoteAddress);
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
@@ -23,12 +23,12 @@ import java.util.Map;
  */
 public final class ConditionVariablesBuilder {
 
-  private Map<String, String> headers;
-  private Map<String, String> params;
-  private Map<String, String> cookies;
-  private String path;
-  private String method;
-  private String remoteAddress;
+  private Map<String, String> headers = Map.of();
+  private Map<String, String> params = Map.of();
+  private Map<String, String> cookies = Map.of();
+  private String path = "";
+  private String method = "";
+  private String remoteAddress = "";
 
   /** Sets the {@code headers} variable. */
   public ConditionVariablesBuilder headers(Map<String, String> headers) {

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
@@ -1,0 +1,69 @@
+package net.brightroom.featureflag.core.condition;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builder for constructing the variables map passed to {@link FeatureFlagConditionEvaluator} and
+ * {@link ReactiveFeatureFlagConditionEvaluator}.
+ *
+ * <p>Centralizes the variable key names so that all modules ({@code webmvc}, {@code webflux}) use
+ * consistent keys. Each module extracts the request-specific data and delegates to this builder to
+ * construct the final map.
+ *
+ * <p>Available variable keys:
+ *
+ * <ul>
+ *   <li>{@code headers} — {@code Map<String, String>} of request headers (first value per name)
+ *   <li>{@code params} — {@code Map<String, String>} of query parameters (first value per name)
+ *   <li>{@code cookies} — {@code Map<String, String>} of cookie values keyed by cookie name
+ *   <li>{@code path} — {@code String} request path (e.g. {@code /api/resource})
+ *   <li>{@code method} — {@code String} HTTP method (e.g. {@code GET}, {@code POST})
+ *   <li>{@code remoteAddress} — {@code String} client IP address
+ * </ul>
+ */
+public final class ConditionVariablesBuilder {
+
+  private final Map<String, Object> variables = new HashMap<>();
+
+  /** Sets the {@code headers} variable. */
+  public ConditionVariablesBuilder headers(Map<String, String> headers) {
+    variables.put("headers", headers);
+    return this;
+  }
+
+  /** Sets the {@code params} variable. */
+  public ConditionVariablesBuilder params(Map<String, String> params) {
+    variables.put("params", params);
+    return this;
+  }
+
+  /** Sets the {@code cookies} variable. */
+  public ConditionVariablesBuilder cookies(Map<String, String> cookies) {
+    variables.put("cookies", cookies);
+    return this;
+  }
+
+  /** Sets the {@code path} variable. */
+  public ConditionVariablesBuilder path(String path) {
+    variables.put("path", path);
+    return this;
+  }
+
+  /** Sets the {@code method} variable. */
+  public ConditionVariablesBuilder method(String method) {
+    variables.put("method", method);
+    return this;
+  }
+
+  /** Sets the {@code remoteAddress} variable. */
+  public ConditionVariablesBuilder remoteAddress(String remoteAddress) {
+    variables.put("remoteAddress", remoteAddress);
+    return this;
+  }
+
+  /** Returns the built variables map. */
+  public Map<String, Object> build() {
+    return variables;
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ConditionVariablesBuilder.java
@@ -64,6 +64,6 @@ public final class ConditionVariablesBuilder {
 
   /** Returns the built variables map. */
   public Map<String, Object> build() {
-    return variables;
+    return Map.copyOf(variables);
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/FeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/FeatureFlagConditionEvaluator.java
@@ -1,0 +1,31 @@
+package net.brightroom.featureflag.core.condition;
+
+import java.util.Map;
+
+/**
+ * SPI for evaluating SpEL condition expressions against request context variables.
+ *
+ * <p>Implementations evaluate a SpEL expression with the given variables and return whether the
+ * condition is satisfied. The default implementation uses {@link
+ * org.springframework.expression.spel.support.SimpleEvaluationContext} for safe evaluation.
+ *
+ * <p>Register a custom bean to replace the default implementation:
+ *
+ * <pre>{@code
+ * @Bean
+ * FeatureFlagConditionEvaluator customEvaluator() {
+ *     return (expression, variables) -> ...;
+ * }
+ * }</pre>
+ */
+public interface FeatureFlagConditionEvaluator {
+
+  /**
+   * Evaluates a SpEL condition expression against the given variables.
+   *
+   * @param expression the SpEL expression to evaluate
+   * @param variables the variables available in the expression context
+   * @return {@code true} if the condition is satisfied
+   */
+  boolean evaluate(String expression, Map<String, Object> variables);
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/FeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/FeatureFlagConditionEvaluator.java
@@ -1,7 +1,5 @@
 package net.brightroom.featureflag.core.condition;
 
-import java.util.Map;
-
 /**
  * SPI for evaluating SpEL condition expressions against request context variables.
  *
@@ -27,5 +25,5 @@ public interface FeatureFlagConditionEvaluator {
    * @param variables the variables available in the expression context
    * @return {@code true} if the condition is satisfied
    */
-  boolean evaluate(String expression, Map<String, Object> variables);
+  boolean evaluate(String expression, ConditionVariables variables);
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ReactiveFeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ReactiveFeatureFlagConditionEvaluator.java
@@ -1,6 +1,5 @@
 package net.brightroom.featureflag.core.condition;
 
-import java.util.Map;
 import reactor.core.publisher.Mono;
 
 /**
@@ -32,5 +31,5 @@ public interface ReactiveFeatureFlagConditionEvaluator {
    * @param variables the variables available in the expression context
    * @return a {@link Mono} emitting {@code true} if the condition is satisfied
    */
-  Mono<Boolean> evaluate(String expression, Map<String, Object> variables);
+  Mono<Boolean> evaluate(String expression, ConditionVariables variables);
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/ReactiveFeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/ReactiveFeatureFlagConditionEvaluator.java
@@ -1,0 +1,36 @@
+package net.brightroom.featureflag.core.condition;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for evaluating SpEL condition expressions against request context variables.
+ *
+ * <p>Implementations evaluate a SpEL expression with the given variables and return a {@link
+ * Mono}{@code <Boolean>} indicating whether the condition is satisfied. The default implementation
+ * wraps {@link SpelFeatureFlagConditionEvaluator} via {@link Mono#fromCallable}.
+ *
+ * <p>Register a custom bean to replace the default implementation:
+ *
+ * <pre>{@code
+ * @Bean
+ * ReactiveFeatureFlagConditionEvaluator customEvaluator() {
+ *     return (expression, variables) -> ...;
+ * }
+ * }</pre>
+ *
+ * <p>Custom implementations that perform non-blocking I/O (e.g., querying a remote condition
+ * service) should return a {@link Mono} that executes on an appropriate scheduler and must not
+ * block the event loop thread.
+ */
+public interface ReactiveFeatureFlagConditionEvaluator {
+
+  /**
+   * Evaluates a SpEL condition expression against the given variables.
+   *
+   * @param expression the SpEL expression to evaluate
+   * @param variables the variables available in the expression context
+   * @return a {@link Mono} emitting {@code true} if the condition is satisfied
+   */
+  Mono<Boolean> evaluate(String expression, Map<String, Object> variables);
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluator.java
@@ -1,0 +1,66 @@
+package net.brightroom.featureflag.core.condition;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.context.expression.MapAccessor;
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ParseException;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.DataBindingPropertyAccessor;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+
+/**
+ * Default {@link FeatureFlagConditionEvaluator} implementation using Spring Expression Language
+ * (SpEL).
+ *
+ * <p>Uses {@link SimpleEvaluationContext} with {@link DataBindingPropertyAccessor} (read-only) and
+ * {@link MapAccessor} to safely evaluate expressions. Type references ({@code T(...)}),
+ * constructors ({@code new ...}), and bean references ({@code @beanName}) are structurally
+ * excluded.
+ *
+ * <p>Parsed expressions are cached in a {@link ConcurrentHashMap} for performance, since condition
+ * expressions are static (annotation-derived).
+ */
+public class SpelFeatureFlagConditionEvaluator implements FeatureFlagConditionEvaluator {
+
+  private static final Log log = LogFactory.getLog(SpelFeatureFlagConditionEvaluator.class);
+
+  private final SpelExpressionParser parser = new SpelExpressionParser();
+  private final ConcurrentMap<String, Expression> cache = new ConcurrentHashMap<>();
+  private final boolean failOnError;
+
+  /**
+   * Creates a new {@code SpelFeatureFlagConditionEvaluator}.
+   *
+   * @param failOnError when {@code true}, evaluation errors result in {@code false} (fail-closed);
+   *     when {@code false}, errors result in {@code true} (fail-open)
+   */
+  public SpelFeatureFlagConditionEvaluator(boolean failOnError) {
+    this.failOnError = failOnError;
+  }
+
+  @Override
+  public boolean evaluate(String expression, Map<String, Object> variables) {
+    try {
+      Expression expr = cache.computeIfAbsent(expression, parser::parseExpression);
+      SimpleEvaluationContext context =
+          SimpleEvaluationContext.forPropertyAccessors(
+                  DataBindingPropertyAccessor.forReadOnlyAccess(), new MapAccessor())
+              .withRootObject(variables)
+              .build();
+      Boolean result = expr.getValue(context, Boolean.class);
+      return Boolean.TRUE.equals(result);
+    } catch (EvaluationException | ParseException e) {
+      log.warn(
+          "Failed to evaluate feature flag condition expression '"
+              + expression
+              + "': "
+              + e.getMessage());
+      return !failOnError;
+    }
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluator.java
@@ -28,6 +28,9 @@ import org.springframework.expression.spel.support.SimpleEvaluationContext;
 public class SpelFeatureFlagConditionEvaluator implements FeatureFlagConditionEvaluator {
 
   private static final Log log = LogFactory.getLog(SpelFeatureFlagConditionEvaluator.class);
+  private static final DataBindingPropertyAccessor READ_ONLY_ACCESSOR =
+      DataBindingPropertyAccessor.forReadOnlyAccess();
+  private static final MapAccessor MAP_ACCESSOR = new MapAccessor();
 
   private final SpelExpressionParser parser = new SpelExpressionParser();
   private final ConcurrentMap<String, Expression> cache = new ConcurrentHashMap<>();
@@ -48,8 +51,7 @@ public class SpelFeatureFlagConditionEvaluator implements FeatureFlagConditionEv
     try {
       Expression expr = cache.computeIfAbsent(expression, parser::parseExpression);
       SimpleEvaluationContext context =
-          SimpleEvaluationContext.forPropertyAccessors(
-                  DataBindingPropertyAccessor.forReadOnlyAccess(), new MapAccessor())
+          SimpleEvaluationContext.forPropertyAccessors(READ_ONLY_ACCESSOR, MAP_ACCESSOR)
               .withRootObject(variables)
               .build();
       Boolean result = expr.getValue(context, Boolean.class);

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluator.java
@@ -1,11 +1,9 @@
 package net.brightroom.featureflag.core.condition;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.context.expression.MapAccessor;
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParseException;
@@ -17,10 +15,10 @@ import org.springframework.expression.spel.support.SimpleEvaluationContext;
  * Default {@link FeatureFlagConditionEvaluator} implementation using Spring Expression Language
  * (SpEL).
  *
- * <p>Uses {@link SimpleEvaluationContext} with {@link DataBindingPropertyAccessor} (read-only) and
- * {@link MapAccessor} to safely evaluate expressions. Type references ({@code T(...)}),
- * constructors ({@code new ...}), and bean references ({@code @beanName}) are structurally
- * excluded.
+ * <p>Uses {@link SimpleEvaluationContext} with {@link DataBindingPropertyAccessor} (read-only) to
+ * safely evaluate expressions against a typed {@link ConditionVariables} root object. Type
+ * references ({@code T(...)}), constructors ({@code new ...}), and bean references ({@code
+ * @beanName}) are structurally excluded.
  *
  * <p>Parsed expressions are cached in a {@link ConcurrentHashMap} for performance, since condition
  * expressions are static (annotation-derived).
@@ -30,7 +28,6 @@ public class SpelFeatureFlagConditionEvaluator implements FeatureFlagConditionEv
   private static final Log log = LogFactory.getLog(SpelFeatureFlagConditionEvaluator.class);
   private static final DataBindingPropertyAccessor READ_ONLY_ACCESSOR =
       DataBindingPropertyAccessor.forReadOnlyAccess();
-  private static final MapAccessor MAP_ACCESSOR = new MapAccessor();
 
   private final SpelExpressionParser parser = new SpelExpressionParser();
   private final ConcurrentMap<String, Expression> cache = new ConcurrentHashMap<>();
@@ -47,21 +44,20 @@ public class SpelFeatureFlagConditionEvaluator implements FeatureFlagConditionEv
   }
 
   @Override
-  public boolean evaluate(String expression, Map<String, Object> variables) {
+  public boolean evaluate(String expression, ConditionVariables variables) {
     try {
       Expression expr = cache.computeIfAbsent(expression, parser::parseExpression);
       SimpleEvaluationContext context =
-          SimpleEvaluationContext.forPropertyAccessors(READ_ONLY_ACCESSOR, MAP_ACCESSOR)
+          SimpleEvaluationContext.forPropertyAccessors(READ_ONLY_ACCESSOR)
               .withRootObject(variables)
               .build();
       Boolean result = expr.getValue(context, Boolean.class);
       return Boolean.TRUE.equals(result);
     } catch (EvaluationException | ParseException e) {
       log.warn(
-          "Failed to evaluate feature flag condition expression '"
-              + expression
-              + "': "
-              + e.getMessage());
+          String.format(
+              "Failed to evaluate feature flag condition expression '%s': %s",
+              expression, e.getMessage()));
       return !failOnError;
     }
   }

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluator.java
@@ -1,6 +1,5 @@
 package net.brightroom.featureflag.core.condition;
 
-import java.util.Map;
 import reactor.core.publisher.Mono;
 
 /**
@@ -27,7 +26,7 @@ public class SpelReactiveFeatureFlagConditionEvaluator
   }
 
   @Override
-  public Mono<Boolean> evaluate(String expression, Map<String, Object> variables) {
+  public Mono<Boolean> evaluate(String expression, ConditionVariables variables) {
     return Mono.fromCallable(() -> delegate.evaluate(expression, variables));
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluator.java
@@ -1,0 +1,33 @@
+package net.brightroom.featureflag.core.condition;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default {@link ReactiveFeatureFlagConditionEvaluator} that wraps a synchronous {@link
+ * FeatureFlagConditionEvaluator} via {@link Mono#fromCallable}.
+ *
+ * <p>This implementation is CPU-bound and runs on the subscribing thread. It is suitable for the
+ * default SpEL-based evaluation which is fast. Custom implementations that need to perform
+ * non-blocking I/O should implement {@link ReactiveFeatureFlagConditionEvaluator} directly and
+ * subscribe on an appropriate scheduler.
+ */
+public class SpelReactiveFeatureFlagConditionEvaluator
+    implements ReactiveFeatureFlagConditionEvaluator {
+
+  private final FeatureFlagConditionEvaluator delegate;
+
+  /**
+   * Creates a new {@code SpelReactiveFeatureFlagConditionEvaluator}.
+   *
+   * @param delegate the synchronous evaluator to delegate to; must not be null
+   */
+  public SpelReactiveFeatureFlagConditionEvaluator(FeatureFlagConditionEvaluator delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Mono<Boolean> evaluate(String expression, Map<String, Object> variables) {
+    return Mono.fromCallable(() -> delegate.evaluate(expression, variables));
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/ConditionProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/ConditionProperties.java
@@ -1,0 +1,37 @@
+package net.brightroom.featureflag.core.properties;
+
+/**
+ * Properties for feature flag condition evaluation behavior.
+ *
+ * <p>Configuration example in {@code application.yml}:
+ *
+ * <pre>{@code
+ * feature-flags:
+ *   condition:
+ *     fail-on-error: true
+ * }</pre>
+ *
+ * <p>When {@code fail-on-error} is {@code true} (default), condition evaluation errors cause the
+ * feature to be denied (fail-closed). When {@code false}, errors cause the condition check to be
+ * skipped (fail-open).
+ */
+public class ConditionProperties {
+
+  private boolean failOnError = true;
+
+  /**
+   * Returns whether condition evaluation errors should cause access denial.
+   *
+   * @return {@code true} for fail-closed (default), {@code false} for fail-open
+   */
+  public boolean failOnError() {
+    return failOnError;
+  }
+
+  // for property binding
+  void setFailOnError(boolean failOnError) {
+    this.failOnError = failOnError;
+  }
+
+  ConditionProperties() {}
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
@@ -30,6 +30,7 @@ public class FeatureFlagProperties {
 
   private Map<String, FeatureConfiguration> features = new HashMap<>();
   private ResponseProperties response = new ResponseProperties();
+  private ConditionProperties condition = new ConditionProperties();
   private boolean defaultEnabled = false;
 
   /**
@@ -76,6 +77,15 @@ public class FeatureFlagProperties {
   }
 
   /**
+   * Returns the condition evaluation properties.
+   *
+   * @return the condition properties
+   */
+  public ConditionProperties condition() {
+    return condition;
+  }
+
+  /**
    * Returns whether undefined feature flags are enabled by default.
    *
    * @return {@code true} if undefined flags are enabled (fail-open), {@code false} if disabled
@@ -93,6 +103,11 @@ public class FeatureFlagProperties {
   // for property binding
   void setResponse(ResponseProperties response) {
     this.response = response;
+  }
+
+  // for property binding
+  void setCondition(ConditionProperties condition) {
+    this.condition = condition;
   }
 
   // for property binding

--- a/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -45,6 +45,12 @@
       "type": "java.lang.Boolean",
       "description": "Whether undefined feature flags are enabled by default. Defaults to false (fail-closed): undefined flags block access. Set to true for fail-open behavior: undefined flags allow access.",
       "defaultValue": false
+    },
+    {
+      "name": "feature-flags.condition.fail-on-error",
+      "type": "java.lang.Boolean",
+      "description": "Whether condition evaluation errors should cause access denial. Defaults to true (fail-closed): evaluation errors block access. Set to false for fail-open behavior: evaluation errors allow access.",
+      "defaultValue": true
     }
   ]
 }

--- a/core/src/test/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluatorTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluatorTest.java
@@ -11,15 +11,15 @@ class SpelFeatureFlagConditionEvaluatorTest {
   private final SpelFeatureFlagConditionEvaluator evaluator =
       new SpelFeatureFlagConditionEvaluator(true);
 
-  private Map<String, Object> buildVariables() {
-    Map<String, Object> variables = new HashMap<>();
-    variables.put("headers", new HashMap<>(Map.of("X-Beta", "true", "X-Region", "us-east-1")));
-    variables.put("params", new HashMap<>(Map.of("variant", "B", "debug", "true")));
-    variables.put("cookies", new HashMap<>(Map.of("session", "abc123")));
-    variables.put("path", "/api/v2/users");
-    variables.put("method", "POST");
-    variables.put("remoteAddress", "192.168.1.1");
-    return variables;
+  private ConditionVariables buildVariables() {
+    return new ConditionVariablesBuilder()
+        .headers(new HashMap<>(Map.of("X-Beta", "true", "X-Region", "us-east-1")))
+        .params(new HashMap<>(Map.of("variant", "B", "debug", "true")))
+        .cookies(new HashMap<>(Map.of("session", "abc123")))
+        .path("/api/v2/users")
+        .method("POST")
+        .remoteAddress("192.168.1.1")
+        .build();
   }
 
   // --- header checks ---
@@ -115,8 +115,15 @@ class SpelFeatureFlagConditionEvaluatorTest {
 
   @Test
   void evaluate_returnsFalse_whenHeaderMapIsEmpty() {
-    Map<String, Object> variables = buildVariables();
-    variables.put("headers", new HashMap<>());
+    ConditionVariables variables =
+        new ConditionVariablesBuilder()
+            .headers(new HashMap<>())
+            .params(new HashMap<>(Map.of("variant", "B", "debug", "true")))
+            .cookies(new HashMap<>(Map.of("session", "abc123")))
+            .path("/api/v2/users")
+            .method("POST")
+            .remoteAddress("192.168.1.1")
+            .build();
     assertThat(evaluator.evaluate("headers['X-Beta'] != null", variables)).isFalse();
   }
 
@@ -156,7 +163,7 @@ class SpelFeatureFlagConditionEvaluatorTest {
 
   @Test
   void evaluate_cachesExpression_acrossMultipleEvaluations() {
-    Map<String, Object> variables = buildVariables();
+    ConditionVariables variables = buildVariables();
     // Evaluate the same expression multiple times; should not throw
     for (int i = 0; i < 5; i++) {
       assertThat(evaluator.evaluate("headers['X-Beta'] != null", variables)).isTrue();

--- a/core/src/test/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluatorTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/condition/SpelFeatureFlagConditionEvaluatorTest.java
@@ -1,0 +1,165 @@
+package net.brightroom.featureflag.core.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SpelFeatureFlagConditionEvaluatorTest {
+
+  private final SpelFeatureFlagConditionEvaluator evaluator =
+      new SpelFeatureFlagConditionEvaluator(true);
+
+  private Map<String, Object> buildVariables() {
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("headers", new HashMap<>(Map.of("X-Beta", "true", "X-Region", "us-east-1")));
+    variables.put("params", new HashMap<>(Map.of("variant", "B", "debug", "true")));
+    variables.put("cookies", new HashMap<>(Map.of("session", "abc123")));
+    variables.put("path", "/api/v2/users");
+    variables.put("method", "POST");
+    variables.put("remoteAddress", "192.168.1.1");
+    return variables;
+  }
+
+  // --- header checks ---
+
+  @Test
+  void evaluate_returnsTrue_whenHeaderExists() {
+    assertThat(evaluator.evaluate("headers['X-Beta'] != null", buildVariables())).isTrue();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenHeaderDoesNotExist() {
+    assertThat(evaluator.evaluate("headers['X-Missing'] != null", buildVariables())).isFalse();
+  }
+
+  @Test
+  void evaluate_returnsTrue_whenHeaderValueMatches() {
+    assertThat(evaluator.evaluate("headers['X-Region'] == 'us-east-1'", buildVariables())).isTrue();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenHeaderValueDoesNotMatch() {
+    assertThat(evaluator.evaluate("headers['X-Region'] == 'eu-west-1'", buildVariables()))
+        .isFalse();
+  }
+
+  // --- param checks ---
+
+  @Test
+  void evaluate_returnsTrue_whenParamValueMatches() {
+    assertThat(evaluator.evaluate("params['variant'] == 'B'", buildVariables())).isTrue();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenParamValueDoesNotMatch() {
+    assertThat(evaluator.evaluate("params['variant'] == 'A'", buildVariables())).isFalse();
+  }
+
+  // --- cookie checks ---
+
+  @Test
+  void evaluate_returnsTrue_whenCookieExists() {
+    assertThat(evaluator.evaluate("cookies['session'] != null", buildVariables())).isTrue();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenCookieDoesNotExist() {
+    assertThat(evaluator.evaluate("cookies['missing'] != null", buildVariables())).isFalse();
+  }
+
+  // --- path checks ---
+
+  @Test
+  void evaluate_returnsTrue_whenPathMatches() {
+    assertThat(evaluator.evaluate("path == '/api/v2/users'", buildVariables())).isTrue();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenPathDoesNotMatch() {
+    assertThat(evaluator.evaluate("path == '/api/v1/users'", buildVariables())).isFalse();
+  }
+
+  // --- method checks ---
+
+  @Test
+  void evaluate_returnsTrue_whenMethodMatches() {
+    assertThat(evaluator.evaluate("method == 'POST'", buildVariables())).isTrue();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenMethodDoesNotMatch() {
+    assertThat(evaluator.evaluate("method == 'GET'", buildVariables())).isFalse();
+  }
+
+  // --- compound conditions ---
+
+  @Test
+  void evaluate_returnsTrue_whenCompoundConditionSatisfied() {
+    assertThat(
+            evaluator.evaluate(
+                "headers['X-Beta'] != null && params['debug'] == 'true'", buildVariables()))
+        .isTrue();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenCompoundConditionPartiallyFails() {
+    assertThat(
+            evaluator.evaluate(
+                "headers['X-Beta'] != null && params['variant'] == 'A'", buildVariables()))
+        .isFalse();
+  }
+
+  // --- empty variables ---
+
+  @Test
+  void evaluate_returnsFalse_whenHeaderMapIsEmpty() {
+    Map<String, Object> variables = buildVariables();
+    variables.put("headers", new HashMap<>());
+    assertThat(evaluator.evaluate("headers['X-Beta'] != null", variables)).isFalse();
+  }
+
+  // --- error handling with failOnError=true (fail-closed) ---
+
+  @Test
+  void evaluate_returnsFalse_whenExpressionIsInvalid_failOnErrorTrue() {
+    assertThat(evaluator.evaluate("this is not valid SpEL !!!", buildVariables())).isFalse();
+  }
+
+  // --- error handling with failOnError=false (fail-open) ---
+
+  @Test
+  void evaluate_returnsTrue_whenExpressionIsInvalid_failOnErrorFalse() {
+    SpelFeatureFlagConditionEvaluator failOpenEvaluator =
+        new SpelFeatureFlagConditionEvaluator(false);
+    assertThat(failOpenEvaluator.evaluate("this is not valid SpEL !!!", buildVariables())).isTrue();
+  }
+
+  // --- security: type reference and constructor injection blocked ---
+
+  @Test
+  void evaluate_returnsFalse_whenTypeReferenceAttempted() {
+    // T(java.lang.Runtime).getRuntime().exec('...') should be rejected by SimpleEvaluationContext
+    assertThat(
+            evaluator.evaluate(
+                "T(java.lang.Runtime).getRuntime().exec('whoami')", buildVariables()))
+        .isFalse();
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenConstructorAttempted() {
+    assertThat(evaluator.evaluate("new java.io.File('/etc/passwd')", buildVariables())).isFalse();
+  }
+
+  // --- expression caching ---
+
+  @Test
+  void evaluate_cachesExpression_acrossMultipleEvaluations() {
+    Map<String, Object> variables = buildVariables();
+    // Evaluate the same expression multiple times; should not throw
+    for (int i = 0; i < 5; i++) {
+      assertThat(evaluator.evaluate("headers['X-Beta'] != null", variables)).isTrue();
+    }
+  }
+}

--- a/core/src/test/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluatorTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluatorTest.java
@@ -1,10 +1,12 @@
 package net.brightroom.featureflag.core.condition;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
+import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -15,10 +17,21 @@ class SpelReactiveFeatureFlagConditionEvaluatorTest {
 
   @Mock FeatureFlagConditionEvaluator delegate;
 
+  private ConditionVariables buildVariables() {
+    return new ConditionVariablesBuilder()
+        .headers(new HashMap<>())
+        .params(new HashMap<>())
+        .cookies(new HashMap<>())
+        .path("/test")
+        .method("GET")
+        .remoteAddress("127.0.0.1")
+        .build();
+  }
+
   @Test
   void evaluate_returnsTrue_whenDelegateReturnsTrue() {
-    Map<String, Object> variables = Map.of("method", "GET");
-    when(delegate.evaluate("method == 'GET'", variables)).thenReturn(true);
+    ConditionVariables variables = buildVariables();
+    when(delegate.evaluate(eq("method == 'GET'"), any(ConditionVariables.class))).thenReturn(true);
 
     SpelReactiveFeatureFlagConditionEvaluator evaluator =
         new SpelReactiveFeatureFlagConditionEvaluator(delegate);
@@ -26,13 +39,13 @@ class SpelReactiveFeatureFlagConditionEvaluatorTest {
     Boolean result = evaluator.evaluate("method == 'GET'", variables).block();
 
     assertThat(result).isTrue();
-    verify(delegate).evaluate("method == 'GET'", variables);
+    verify(delegate).evaluate(eq("method == 'GET'"), any(ConditionVariables.class));
   }
 
   @Test
   void evaluate_returnsFalse_whenDelegateReturnsFalse() {
-    Map<String, Object> variables = Map.of("method", "POST");
-    when(delegate.evaluate("method == 'GET'", variables)).thenReturn(false);
+    ConditionVariables variables = buildVariables();
+    when(delegate.evaluate(eq("method == 'GET'"), any(ConditionVariables.class))).thenReturn(false);
 
     SpelReactiveFeatureFlagConditionEvaluator evaluator =
         new SpelReactiveFeatureFlagConditionEvaluator(delegate);
@@ -40,6 +53,6 @@ class SpelReactiveFeatureFlagConditionEvaluatorTest {
     Boolean result = evaluator.evaluate("method == 'GET'", variables).block();
 
     assertThat(result).isFalse();
-    verify(delegate).evaluate("method == 'GET'", variables);
+    verify(delegate).evaluate(eq("method == 'GET'"), any(ConditionVariables.class));
   }
 }

--- a/core/src/test/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluatorTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/condition/SpelReactiveFeatureFlagConditionEvaluatorTest.java
@@ -1,0 +1,45 @@
+package net.brightroom.featureflag.core.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SpelReactiveFeatureFlagConditionEvaluatorTest {
+
+  @Mock FeatureFlagConditionEvaluator delegate;
+
+  @Test
+  void evaluate_returnsTrue_whenDelegateReturnsTrue() {
+    Map<String, Object> variables = Map.of("method", "GET");
+    when(delegate.evaluate("method == 'GET'", variables)).thenReturn(true);
+
+    SpelReactiveFeatureFlagConditionEvaluator evaluator =
+        new SpelReactiveFeatureFlagConditionEvaluator(delegate);
+
+    Boolean result = evaluator.evaluate("method == 'GET'", variables).block();
+
+    assertThat(result).isTrue();
+    verify(delegate).evaluate("method == 'GET'", variables);
+  }
+
+  @Test
+  void evaluate_returnsFalse_whenDelegateReturnsFalse() {
+    Map<String, Object> variables = Map.of("method", "POST");
+    when(delegate.evaluate("method == 'GET'", variables)).thenReturn(false);
+
+    SpelReactiveFeatureFlagConditionEvaluator evaluator =
+        new SpelReactiveFeatureFlagConditionEvaluator(delegate);
+
+    Boolean result = evaluator.evaluate("method == 'GET'", variables).block();
+
+    assertThat(result).isFalse();
+    verify(delegate).evaluate("method == 'GET'", variables);
+  }
+}

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
@@ -1,0 +1,82 @@
+package net.brightroom.featureflag.webflux;
+
+import net.brightroom.featureflag.webflux.configuration.FeatureFlagWebFluxTestAutoConfiguration;
+import net.brightroom.featureflag.webflux.endpoint.FeatureFlagConditionController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(controllers = FeatureFlagConditionController.class)
+@Import(FeatureFlagWebFluxTestAutoConfiguration.class)
+@TestPropertySource(
+    properties = {
+      "feature-flags.features.conditional-feature.enabled=true",
+    })
+class FeatureFlagAspectConditionIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenHeaderConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/condition/header")
+        .header("X-Beta", "true")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenHeaderConditionIsNotSatisfied() {
+    webTestClient
+        .get()
+        .uri("/condition/header")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Feature 'conditional-feature' is not available",
+              "instance" : "/condition/header",
+              "status" : 403,
+              "title" : "Feature flag access denied",
+              "type" : "https://github.com/bright-room/feature-flag-spring-boot-starter#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldAllowAccess_whenParamConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/condition/param?variant=B")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamConditionIsNotSatisfied() {
+    webTestClient.get().uri("/condition/param?variant=A").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamIsMissing() {
+    webTestClient.get().uri("/condition/param").exchange().expectStatus().isForbidden();
+  }
+
+  @Autowired
+  FeatureFlagAspectConditionIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
@@ -96,6 +96,12 @@ class FeatureFlagAspectConditionIntegrationTest {
         .isEqualTo("Allowed");
   }
 
+  @Test
+  void shouldBlockAccess_whenRemoteAddressConditionIsNotSatisfied() {
+    // @WebFluxTest slice does not set a real remote address, so the condition fails
+    webTestClient.get().uri("/condition/remote-address").exchange().expectStatus().isForbidden();
+  }
+
   @Autowired
   FeatureFlagAspectConditionIntegrationTest(WebTestClient webTestClient) {
     this.webTestClient = webTestClient;

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @TestPropertySource(
     properties = {
       "feature-flags.features.conditional-feature.enabled=true",
+      "feature-flags.features.conditional-feature.rollout=100",
     })
 class FeatureFlagAspectConditionIntegrationTest {
 
@@ -73,6 +74,26 @@ class FeatureFlagAspectConditionIntegrationTest {
   @Test
   void shouldBlockAccess_whenParamIsMissing() {
     webTestClient.get().uri("/condition/param").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
+  void shouldBlockAccess_onConditionWithRollout_whenConditionIsNotSatisfied() {
+    // condition fails (no X-Beta header) — access denied regardless of rollout
+    webTestClient.get().uri("/condition/with-rollout").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
+  void shouldAllowAccess_onConditionWithRollout_whenConditionSatisfiedAndRolloutFull() {
+    // rollout overridden to 100% via property, condition satisfied
+    webTestClient
+        .get()
+        .uri("/condition/with-rollout")
+        .header("X-Beta", "true")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
   }
 
   @Autowired

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagHandlerFilterFunctionConditionIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagHandlerFilterFunctionConditionIntegrationTest.java
@@ -53,6 +53,28 @@ class FeatureFlagHandlerFilterFunctionConditionIntegrationTest {
             """);
   }
 
+  @Test
+  void shouldAllowAccess_whenParamConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/param?variant=B")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamConditionIsNotSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/param?variant=A")
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
   @Autowired
   FeatureFlagHandlerFilterFunctionConditionIntegrationTest(WebTestClient webTestClient) {
     this.webTestClient = webTestClient;

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagHandlerFilterFunctionConditionIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagHandlerFilterFunctionConditionIntegrationTest.java
@@ -1,0 +1,60 @@
+package net.brightroom.featureflag.webflux;
+
+import net.brightroom.featureflag.webflux.configuration.FeatureFlagWebFluxTestAutoConfiguration;
+import net.brightroom.featureflag.webflux.endpoint.FeatureFlagRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest
+@Import({FeatureFlagWebFluxTestAutoConfiguration.class, FeatureFlagRouterConfiguration.class})
+@TestPropertySource(
+    properties = {
+      "feature-flags.features.conditional-feature.enabled=true",
+    })
+class FeatureFlagHandlerFilterFunctionConditionIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenHeaderConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/header")
+        .header("X-Beta", "true")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenHeaderConditionIsNotSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/header")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Feature 'conditional-feature' is not available",
+              "instance" : "/functional/condition/header",
+              "status" : 403,
+              "title" : "Feature flag access denied",
+              "type" : "https://github.com/bright-room/feature-flag-spring-boot-starter#response-types"
+            }
+            """);
+  }
+
+  @Autowired
+  FeatureFlagHandlerFilterFunctionConditionIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagNettyIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagNettyIntegrationTest.java
@@ -45,4 +45,17 @@ class FeatureFlagNettyIntegrationTest {
         .expectStatus()
         .isForbidden();
   }
+
+  @Test
+  void shouldAllowAccess_whenRemoteAddressConditionIsSatisfied() {
+    // Real Netty server: remoteAddress resolves to 127.0.0.1 for localhost connections
+    webTestClient
+        .get()
+        .uri("/condition/remote-address")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
 }

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagConditionController.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagConditionController.java
@@ -1,0 +1,30 @@
+package net.brightroom.featureflag.webflux.endpoint;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class FeatureFlagConditionController {
+
+  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null")
+  @GetMapping("/condition/header")
+  Mono<String> headerCondition() {
+    return Mono.just("Allowed");
+  }
+
+  @FeatureFlag(value = "conditional-feature", condition = "params['variant'] == 'B'")
+  @GetMapping("/condition/param")
+  Mono<String> paramCondition() {
+    return Mono.just("Allowed");
+  }
+
+  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null", rollout = 50)
+  @GetMapping("/condition/with-rollout")
+  Mono<String> conditionWithRollout() {
+    return Mono.just("Allowed");
+  }
+
+  public FeatureFlagConditionController() {}
+}

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagConditionController.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagConditionController.java
@@ -26,5 +26,11 @@ public class FeatureFlagConditionController {
     return Mono.just("Allowed");
   }
 
+  @FeatureFlag(value = "conditional-feature", condition = "remoteAddress == '127.0.0.1'")
+  @GetMapping("/condition/remote-address")
+  Mono<String> remoteAddressCondition() {
+    return Mono.just("Allowed");
+  }
+
   public FeatureFlagConditionController() {}
 }

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagRouterConfiguration.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagRouterConfiguration.java
@@ -72,6 +72,14 @@ public class FeatureFlagRouterConfiguration {
         .build();
   }
 
+  @Bean
+  RouterFunction<ServerResponse> functionalConditionParamRoute() {
+    return route()
+        .GET("/functional/condition/param", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(featureFlagFilter.of("conditional-feature", "params['variant'] == 'B'"))
+        .build();
+  }
+
   public FeatureFlagRouterConfiguration(FeatureFlagHandlerFilterFunction featureFlagFilter) {
     this.featureFlagFilter = featureFlagFilter;
   }

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagRouterConfiguration.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagRouterConfiguration.java
@@ -64,6 +64,14 @@ public class FeatureFlagRouterConfiguration {
         .build();
   }
 
+  @Bean
+  RouterFunction<ServerResponse> functionalConditionRoute() {
+    return route()
+        .GET("/functional/condition/header", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(featureFlagFilter.of("conditional-feature", "headers['X-Beta'] != null"))
+        .build();
+  }
+
   public FeatureFlagRouterConfiguration(FeatureFlagHandlerFilterFunction featureFlagFilter) {
     this.featureFlagFilter = featureFlagFilter;
   }

--- a/webflux/src/integrationTest/resources/application.yaml
+++ b/webflux/src/integrationTest/resources/application.yaml
@@ -8,5 +8,7 @@ feature-flags:
       enabled: true
     disable-class-level-feature:
       enabled: false
+    conditional-feature:
+      enabled: true
   response:
     type: json

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
@@ -78,94 +78,12 @@ public class FeatureFlagAspect {
 
     if (Mono.class.isAssignableFrom(returnType)) {
       return enabledMono.flatMap(
-          enabled -> {
-            if (!enabled) {
-              return Mono.error(new FeatureFlagAccessDeniedException(featureName));
-            }
-            if (!condition.isEmpty()) {
-              return Mono.deferContextual(
-                  ctx -> {
-                    ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
-                    return conditionEvaluator
-                        .evaluate(
-                            condition, ServerHttpConditionVariables.build(exchange.getRequest()))
-                        .flatMap(
-                            passed -> {
-                              if (!passed) {
-                                return Mono.error(
-                                    new FeatureFlagAccessDeniedException(featureName));
-                              }
-                              return proceedMonoWithRollout(
-                                  joinPoint, featureName, rolloutMono, exchange);
-                            });
-                  });
-            }
-            return rolloutMono.flatMap(
-                rollout -> {
-                  if (rollout < 100) {
-                    return Mono.deferContextual(
-                        ctx -> {
-                          ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
-                          return shouldProceed(featureName, exchange, rollout)
-                              .flatMap(
-                                  proceed -> {
-                                    if (!proceed) {
-                                      return Mono.error(
-                                          new FeatureFlagAccessDeniedException(featureName));
-                                    }
-                                    return proceedAsMono(joinPoint);
-                                  });
-                        });
-                  }
-                  return proceedAsMono(joinPoint);
-                });
-          });
+          enabled -> handleMonoEnabled(joinPoint, featureName, condition, rolloutMono, enabled));
     }
 
     if (Flux.class.isAssignableFrom(returnType)) {
       return enabledMono.flatMapMany(
-          enabled -> {
-            if (!enabled) {
-              return Flux.error(new FeatureFlagAccessDeniedException(featureName));
-            }
-            if (!condition.isEmpty()) {
-              return Flux.deferContextual(
-                  ctx -> {
-                    ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
-                    return conditionEvaluator
-                        .evaluate(
-                            condition, ServerHttpConditionVariables.build(exchange.getRequest()))
-                        .flatMapMany(
-                            passed -> {
-                              if (!passed) {
-                                return Flux.error(
-                                    new FeatureFlagAccessDeniedException(featureName));
-                              }
-                              return proceedFluxWithRollout(
-                                  joinPoint, featureName, rolloutMono, exchange);
-                            });
-                  });
-            }
-            return rolloutMono.flatMapMany(
-                rollout -> {
-                  if (rollout < 100) {
-                    return Flux.deferContextual(
-                        ctx -> {
-                          ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
-                          return shouldProceed(featureName, exchange, rollout)
-                              .flatMapMany(
-                                  proceed -> {
-                                    if (!proceed) {
-                                      return Flux.error(
-                                          new FeatureFlagAccessDeniedException(featureName));
-                                    }
-                                    return proceedAsFlux(joinPoint);
-                                  });
-                        });
-                  }
-                  return proceedAsFlux(joinPoint);
-                });
-          });
+          enabled -> handleFluxEnabled(joinPoint, featureName, condition, rolloutMono, enabled));
     }
 
     // Non-reactive return type: not supported in WebFlux
@@ -176,24 +94,145 @@ public class FeatureFlagAspect {
             + "Non-reactive return types are not supported.");
   }
 
+  private Mono<Object> handleMonoEnabled(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      String condition,
+      Mono<Integer> rolloutMono,
+      boolean enabled) {
+    if (!enabled) {
+      return Mono.error(new FeatureFlagAccessDeniedException(featureName));
+    }
+    if (!condition.isEmpty()) {
+      return evaluateConditionForMono(joinPoint, featureName, condition, rolloutMono);
+    }
+    return rolloutMono.flatMap(
+        rollout -> handleMonoRolloutFromContext(joinPoint, featureName, rollout));
+  }
+
+  private Mono<Object> evaluateConditionForMono(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      String condition,
+      Mono<Integer> rolloutMono) {
+    return Mono.deferContextual(
+        ctx -> {
+          ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
+          return conditionEvaluator
+              .evaluate(condition, ServerHttpConditionVariables.build(exchange.getRequest()))
+              .flatMap(
+                  passed ->
+                      handleMonoConditionResult(
+                          joinPoint, featureName, rolloutMono, exchange, passed));
+        });
+  }
+
+  private Mono<Object> handleMonoConditionResult(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      Mono<Integer> rolloutMono,
+      ServerWebExchange exchange,
+      boolean passed) {
+    if (!passed) {
+      return Mono.error(new FeatureFlagAccessDeniedException(featureName));
+    }
+    return proceedMonoWithRollout(joinPoint, featureName, rolloutMono, exchange);
+  }
+
+  private Mono<Object> handleMonoRolloutFromContext(
+      ProceedingJoinPoint joinPoint, String featureName, int rollout) {
+    if (rollout >= 100) {
+      return proceedAsMono(joinPoint);
+    }
+    return Mono.deferContextual(
+        ctx -> {
+          ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
+          return shouldProceed(featureName, exchange, rollout)
+              .flatMap(proceed -> handleMonoProceed(joinPoint, featureName, proceed));
+        });
+  }
+
   private Mono<Object> proceedMonoWithRollout(
       ProceedingJoinPoint joinPoint,
       String featureName,
       Mono<Integer> rolloutMono,
       ServerWebExchange exchange) {
     return rolloutMono.flatMap(
-        rollout -> {
-          if (rollout < 100) {
-            return shouldProceed(featureName, exchange, rollout)
-                .flatMap(
-                    proceed -> {
-                      if (!proceed) {
-                        return Mono.error(new FeatureFlagAccessDeniedException(featureName));
-                      }
-                      return proceedAsMono(joinPoint);
-                    });
-          }
-          return proceedAsMono(joinPoint);
+        rollout -> handleMonoRolloutWithExchange(joinPoint, featureName, exchange, rollout));
+  }
+
+  private Mono<Object> handleMonoRolloutWithExchange(
+      ProceedingJoinPoint joinPoint, String featureName, ServerWebExchange exchange, int rollout) {
+    if (rollout >= 100) {
+      return proceedAsMono(joinPoint);
+    }
+    return shouldProceed(featureName, exchange, rollout)
+        .flatMap(proceed -> handleMonoProceed(joinPoint, featureName, proceed));
+  }
+
+  private Mono<Object> handleMonoProceed(
+      ProceedingJoinPoint joinPoint, String featureName, boolean proceed) {
+    if (!proceed) {
+      return Mono.error(new FeatureFlagAccessDeniedException(featureName));
+    }
+    return proceedAsMono(joinPoint);
+  }
+
+  private Flux<Object> handleFluxEnabled(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      String condition,
+      Mono<Integer> rolloutMono,
+      boolean enabled) {
+    if (!enabled) {
+      return Flux.error(new FeatureFlagAccessDeniedException(featureName));
+    }
+    if (!condition.isEmpty()) {
+      return evaluateConditionForFlux(joinPoint, featureName, condition, rolloutMono);
+    }
+    return rolloutMono.flatMapMany(
+        rollout -> handleFluxRolloutFromContext(joinPoint, featureName, rollout));
+  }
+
+  private Flux<Object> evaluateConditionForFlux(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      String condition,
+      Mono<Integer> rolloutMono) {
+    return Flux.deferContextual(
+        ctx -> {
+          ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
+          return conditionEvaluator
+              .evaluate(condition, ServerHttpConditionVariables.build(exchange.getRequest()))
+              .flatMapMany(
+                  passed ->
+                      handleFluxConditionResult(
+                          joinPoint, featureName, rolloutMono, exchange, passed));
+        });
+  }
+
+  private Flux<Object> handleFluxConditionResult(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      Mono<Integer> rolloutMono,
+      ServerWebExchange exchange,
+      boolean passed) {
+    if (!passed) {
+      return Flux.error(new FeatureFlagAccessDeniedException(featureName));
+    }
+    return proceedFluxWithRollout(joinPoint, featureName, rolloutMono, exchange);
+  }
+
+  private Flux<Object> handleFluxRolloutFromContext(
+      ProceedingJoinPoint joinPoint, String featureName, int rollout) {
+    if (rollout >= 100) {
+      return proceedAsFlux(joinPoint);
+    }
+    return Flux.deferContextual(
+        ctx -> {
+          ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
+          return shouldProceed(featureName, exchange, rollout)
+              .flatMapMany(proceed -> handleFluxProceed(joinPoint, featureName, proceed));
         });
   }
 
@@ -203,19 +242,24 @@ public class FeatureFlagAspect {
       Mono<Integer> rolloutMono,
       ServerWebExchange exchange) {
     return rolloutMono.flatMapMany(
-        rollout -> {
-          if (rollout < 100) {
-            return shouldProceed(featureName, exchange, rollout)
-                .flatMapMany(
-                    proceed -> {
-                      if (!proceed) {
-                        return Flux.error(new FeatureFlagAccessDeniedException(featureName));
-                      }
-                      return proceedAsFlux(joinPoint);
-                    });
-          }
-          return proceedAsFlux(joinPoint);
-        });
+        rollout -> handleFluxRolloutWithExchange(joinPoint, featureName, exchange, rollout));
+  }
+
+  private Flux<Object> handleFluxRolloutWithExchange(
+      ProceedingJoinPoint joinPoint, String featureName, ServerWebExchange exchange, int rollout) {
+    if (rollout >= 100) {
+      return proceedAsFlux(joinPoint);
+    }
+    return shouldProceed(featureName, exchange, rollout)
+        .flatMapMany(proceed -> handleFluxProceed(joinPoint, featureName, proceed));
+  }
+
+  private Flux<Object> handleFluxProceed(
+      ProceedingJoinPoint joinPoint, String featureName, boolean proceed) {
+    if (!proceed) {
+      return Flux.error(new FeatureFlagAccessDeniedException(featureName));
+    }
+    return proceedAsFlux(joinPoint);
   }
 
   /**

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
@@ -1,7 +1,11 @@
 package net.brightroom.featureflag.webflux.aspect;
 
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
@@ -13,6 +17,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -37,6 +42,7 @@ public class FeatureFlagAspect {
   private final ReactiveRolloutStrategy rolloutStrategy;
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
+  private final FeatureFlagConditionEvaluator conditionEvaluator;
 
   /**
    * Around advice that checks the feature flag before proceeding with the annotated method.
@@ -62,6 +68,7 @@ public class FeatureFlagAspect {
     validateAnnotation(annotation);
 
     String featureName = annotation.value();
+    String condition = annotation.condition();
     int annotationRollout = annotation.rollout();
     Mono<Boolean> enabledMono =
         reactiveFeatureFlagProvider.isFeatureEnabled(featureName).defaultIfEmpty(false);
@@ -77,6 +84,17 @@ public class FeatureFlagAspect {
           enabled -> {
             if (!enabled) {
               return Mono.error(new FeatureFlagAccessDeniedException(featureName));
+            }
+            if (!condition.isEmpty()) {
+              return Mono.deferContextual(
+                  ctx -> {
+                    ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
+                    Map<String, Object> variables = buildConditionVariables(exchange.getRequest());
+                    if (!conditionEvaluator.evaluate(condition, variables)) {
+                      return Mono.error(new FeatureFlagAccessDeniedException(featureName));
+                    }
+                    return proceedMonoWithRollout(joinPoint, featureName, rolloutMono, exchange);
+                  });
             }
             return rolloutMono.flatMap(
                 rollout -> {
@@ -106,6 +124,17 @@ public class FeatureFlagAspect {
             if (!enabled) {
               return Flux.error(new FeatureFlagAccessDeniedException(featureName));
             }
+            if (!condition.isEmpty()) {
+              return Flux.deferContextual(
+                  ctx -> {
+                    ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
+                    Map<String, Object> variables = buildConditionVariables(exchange.getRequest());
+                    if (!conditionEvaluator.evaluate(condition, variables)) {
+                      return Flux.error(new FeatureFlagAccessDeniedException(featureName));
+                    }
+                    return proceedFluxWithRollout(joinPoint, featureName, rolloutMono, exchange);
+                  });
+            }
             return rolloutMono.flatMapMany(
                 rollout -> {
                   if (rollout < 100) {
@@ -134,6 +163,48 @@ public class FeatureFlagAspect {
             + ((MethodSignature) joinPoint.getSignature()).getMethod().getName()
             + "' requires a reactive return type (Mono or Flux). "
             + "Non-reactive return types are not supported.");
+  }
+
+  private Mono<Object> proceedMonoWithRollout(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      Mono<Integer> rolloutMono,
+      ServerWebExchange exchange) {
+    return rolloutMono.flatMap(
+        rollout -> {
+          if (rollout < 100) {
+            return shouldProceed(featureName, exchange, rollout)
+                .flatMap(
+                    proceed -> {
+                      if (!proceed) {
+                        return Mono.error(new FeatureFlagAccessDeniedException(featureName));
+                      }
+                      return proceedAsMono(joinPoint);
+                    });
+          }
+          return proceedAsMono(joinPoint);
+        });
+  }
+
+  private Flux<Object> proceedFluxWithRollout(
+      ProceedingJoinPoint joinPoint,
+      String featureName,
+      Mono<Integer> rolloutMono,
+      ServerWebExchange exchange) {
+    return rolloutMono.flatMapMany(
+        rollout -> {
+          if (rollout < 100) {
+            return shouldProceed(featureName, exchange, rollout)
+                .flatMapMany(
+                    proceed -> {
+                      if (!proceed) {
+                        return Flux.error(new FeatureFlagAccessDeniedException(featureName));
+                      }
+                      return proceedAsFlux(joinPoint);
+                    });
+          }
+          return proceedAsFlux(joinPoint);
+        });
   }
 
   /**
@@ -168,6 +239,29 @@ public class FeatureFlagAspect {
     }
   }
 
+  private Map<String, Object> buildConditionVariables(ServerHttpRequest request) {
+    Map<String, Object> variables = new HashMap<>();
+    Map<String, String> headers = new HashMap<>();
+    request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
+    variables.put("headers", headers);
+    Map<String, String> params = new HashMap<>();
+    request.getQueryParams().forEach((name, values) -> params.put(name, values.getFirst()));
+    variables.put("params", params);
+    Map<String, String> cookies = new HashMap<>();
+    request
+        .getCookies()
+        .forEach(
+            (name, cookieList) -> {
+              if (!cookieList.isEmpty()) cookies.put(name, cookieList.getFirst().getValue());
+            });
+    variables.put("cookies", cookies);
+    variables.put("path", request.getPath().value());
+    variables.put("method", request.getMethod().name());
+    InetSocketAddress remoteAddr = request.getRemoteAddress();
+    variables.put("remoteAddress", remoteAddr != null ? remoteAddr.getHostString() : "");
+    return variables;
+  }
+
   private FeatureFlag resolveAnnotation(ProceedingJoinPoint joinPoint) {
     MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
     Method method =
@@ -200,15 +294,18 @@ public class FeatureFlagAspect {
    * @param contextResolver the resolver used to extract context from the current request
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature
+   * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions
    */
   public FeatureFlagAspect(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
       ReactiveRolloutStrategy rolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
-      ReactiveRolloutPercentageProvider rolloutPercentageProvider) {
+      ReactiveRolloutPercentageProvider rolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     this.reactiveFeatureFlagProvider = reactiveFeatureFlagProvider;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionEvaluator = conditionEvaluator;
   }
 }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
@@ -1,14 +1,12 @@
 package net.brightroom.featureflag.webflux.aspect;
 
 import java.lang.reflect.Method;
-import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.Map;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
-import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.webflux.condition.ServerHttpConditionVariables;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -17,7 +15,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -42,7 +39,7 @@ public class FeatureFlagAspect {
   private final ReactiveRolloutStrategy rolloutStrategy;
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
-  private final FeatureFlagConditionEvaluator conditionEvaluator;
+  private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator;
 
   /**
    * Around advice that checks the feature flag before proceeding with the annotated method.
@@ -89,11 +86,18 @@ public class FeatureFlagAspect {
               return Mono.deferContextual(
                   ctx -> {
                     ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
-                    Map<String, Object> variables = buildConditionVariables(exchange.getRequest());
-                    if (!conditionEvaluator.evaluate(condition, variables)) {
-                      return Mono.error(new FeatureFlagAccessDeniedException(featureName));
-                    }
-                    return proceedMonoWithRollout(joinPoint, featureName, rolloutMono, exchange);
+                    return conditionEvaluator
+                        .evaluate(
+                            condition, ServerHttpConditionVariables.build(exchange.getRequest()))
+                        .flatMap(
+                            passed -> {
+                              if (!passed) {
+                                return Mono.error(
+                                    new FeatureFlagAccessDeniedException(featureName));
+                              }
+                              return proceedMonoWithRollout(
+                                  joinPoint, featureName, rolloutMono, exchange);
+                            });
                   });
             }
             return rolloutMono.flatMap(
@@ -128,11 +132,18 @@ public class FeatureFlagAspect {
               return Flux.deferContextual(
                   ctx -> {
                     ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
-                    Map<String, Object> variables = buildConditionVariables(exchange.getRequest());
-                    if (!conditionEvaluator.evaluate(condition, variables)) {
-                      return Flux.error(new FeatureFlagAccessDeniedException(featureName));
-                    }
-                    return proceedFluxWithRollout(joinPoint, featureName, rolloutMono, exchange);
+                    return conditionEvaluator
+                        .evaluate(
+                            condition, ServerHttpConditionVariables.build(exchange.getRequest()))
+                        .flatMapMany(
+                            passed -> {
+                              if (!passed) {
+                                return Flux.error(
+                                    new FeatureFlagAccessDeniedException(featureName));
+                              }
+                              return proceedFluxWithRollout(
+                                  joinPoint, featureName, rolloutMono, exchange);
+                            });
                   });
             }
             return rolloutMono.flatMapMany(
@@ -239,29 +250,6 @@ public class FeatureFlagAspect {
     }
   }
 
-  private Map<String, Object> buildConditionVariables(ServerHttpRequest request) {
-    Map<String, Object> variables = new HashMap<>();
-    Map<String, String> headers = new HashMap<>();
-    request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
-    variables.put("headers", headers);
-    Map<String, String> params = new HashMap<>();
-    request.getQueryParams().forEach((name, values) -> params.put(name, values.getFirst()));
-    variables.put("params", params);
-    Map<String, String> cookies = new HashMap<>();
-    request
-        .getCookies()
-        .forEach(
-            (name, cookieList) -> {
-              if (!cookieList.isEmpty()) cookies.put(name, cookieList.getFirst().getValue());
-            });
-    variables.put("cookies", cookies);
-    variables.put("path", request.getPath().value());
-    variables.put("method", request.getMethod().name());
-    InetSocketAddress remoteAddr = request.getRemoteAddress();
-    variables.put("remoteAddress", remoteAddr != null ? remoteAddr.getHostString() : "");
-    return variables;
-  }
-
   private FeatureFlag resolveAnnotation(ProceedingJoinPoint joinPoint) {
     MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
     Method method =
@@ -294,14 +282,14 @@ public class FeatureFlagAspect {
    * @param contextResolver the resolver used to extract context from the current request
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature
-   * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions
+   * @param conditionEvaluator the reactive evaluator used to evaluate SpEL condition expressions
    */
   public FeatureFlagAspect(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
       ReactiveRolloutStrategy rolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider rolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
     this.reactiveFeatureFlagProvider = reactiveFeatureFlagProvider;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
@@ -2,7 +2,9 @@ package net.brightroom.featureflag.webflux.autoconfigure;
 
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.condition.SpelFeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.SpelReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.InMemoryReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
@@ -94,6 +96,13 @@ public class FeatureFlagWebFluxAutoConfiguration {
     return new SpelFeatureFlagConditionEvaluator(featureFlagProperties.condition().failOnError());
   }
 
+  @Bean
+  @ConditionalOnMissingBean(ReactiveFeatureFlagConditionEvaluator.class)
+  ReactiveFeatureFlagConditionEvaluator reactiveFeatureFlagConditionEvaluator(
+      FeatureFlagConditionEvaluator conditionEvaluator) {
+    return new SpelReactiveFeatureFlagConditionEvaluator(conditionEvaluator);
+  }
+
   /**
    * Propagates {@link ServerWebExchange} into the Reactor context so that {@link FeatureFlagAspect}
    * can access it via {@code Mono.deferContextual} during rollout percentage checks.
@@ -116,7 +125,7 @@ public class FeatureFlagWebFluxAutoConfiguration {
       ReactiveRolloutStrategy reactiveRolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
     return new FeatureFlagAspect(
         reactiveFeatureFlagProvider,
         reactiveRolloutStrategy,
@@ -139,7 +148,7 @@ public class FeatureFlagWebFluxAutoConfiguration {
       ReactiveRolloutStrategy reactiveRolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
     return new FeatureFlagHandlerFilterFunction(
         reactiveFeatureFlagProvider,
         accessDeniedHandlerResolution,

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
@@ -1,6 +1,8 @@
 package net.brightroom.featureflag.webflux.autoconfigure;
 
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.SpelFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.InMemoryReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
@@ -86,6 +88,12 @@ public class FeatureFlagWebFluxAutoConfiguration {
         featureFlagProperties.rolloutPercentages());
   }
 
+  @Bean
+  @ConditionalOnMissingBean
+  FeatureFlagConditionEvaluator featureFlagConditionEvaluator() {
+    return new SpelFeatureFlagConditionEvaluator(featureFlagProperties.condition().failOnError());
+  }
+
   /**
    * Propagates {@link ServerWebExchange} into the Reactor context so that {@link FeatureFlagAspect}
    * can access it via {@code Mono.deferContextual} during rollout percentage checks.
@@ -107,12 +115,14 @@ public class FeatureFlagWebFluxAutoConfiguration {
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
       ReactiveRolloutStrategy reactiveRolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
-      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider) {
+      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     return new FeatureFlagAspect(
         reactiveFeatureFlagProvider,
         reactiveRolloutStrategy,
         contextResolver,
-        reactiveRolloutPercentageProvider);
+        reactiveRolloutPercentageProvider,
+        conditionEvaluator);
   }
 
   @Bean
@@ -128,13 +138,15 @@ public class FeatureFlagWebFluxAutoConfiguration {
       AccessDeniedHandlerFilterResolution accessDeniedHandlerResolution,
       ReactiveRolloutStrategy reactiveRolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
-      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider) {
+      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     return new FeatureFlagHandlerFilterFunction(
         reactiveFeatureFlagProvider,
         accessDeniedHandlerResolution,
         reactiveRolloutStrategy,
         contextResolver,
-        reactiveRolloutPercentageProvider);
+        reactiveRolloutPercentageProvider,
+        conditionEvaluator);
   }
 
   /**

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/condition/ServerHttpConditionVariables.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/condition/ServerHttpConditionVariables.java
@@ -1,0 +1,48 @@
+package net.brightroom.featureflag.webflux.condition;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import net.brightroom.featureflag.core.condition.ConditionVariablesBuilder;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Utility for building the condition variables map from a {@link ServerHttpRequest}.
+ *
+ * <p>Shared by {@link net.brightroom.featureflag.webflux.aspect.FeatureFlagAspect} and {@link
+ * net.brightroom.featureflag.webflux.filter.FeatureFlagHandlerFilterFunction} to avoid duplication.
+ * Key names are defined by {@link ConditionVariablesBuilder}.
+ */
+public final class ServerHttpConditionVariables {
+
+  private ServerHttpConditionVariables() {}
+
+  /**
+   * Builds the condition variables map from the given request.
+   *
+   * @param request the incoming reactive HTTP request
+   * @return a map of condition variables keyed by name
+   */
+  public static Map<String, Object> build(ServerHttpRequest request) {
+    Map<String, String> headers = new HashMap<>();
+    request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
+    Map<String, String> params = new HashMap<>();
+    request.getQueryParams().forEach((name, values) -> params.put(name, values.getFirst()));
+    Map<String, String> cookies = new HashMap<>();
+    request
+        .getCookies()
+        .forEach(
+            (name, cookieList) -> {
+              if (!cookieList.isEmpty()) cookies.put(name, cookieList.getFirst().getValue());
+            });
+    InetSocketAddress remoteAddr = request.getRemoteAddress();
+    return new ConditionVariablesBuilder()
+        .headers(headers)
+        .params(params)
+        .cookies(cookies)
+        .path(request.getPath().value())
+        .method(request.getMethod().name())
+        .remoteAddress(remoteAddr != null ? remoteAddr.getHostString() : "")
+        .build();
+  }
+}

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/condition/ServerHttpConditionVariables.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/condition/ServerHttpConditionVariables.java
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import net.brightroom.featureflag.core.condition.ConditionVariables;
 import net.brightroom.featureflag.core.condition.ConditionVariablesBuilder;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 
@@ -19,12 +20,12 @@ public final class ServerHttpConditionVariables {
   private ServerHttpConditionVariables() {}
 
   /**
-   * Builds the condition variables map from the given request.
+   * Builds the condition variables from the given request.
    *
    * @param request the incoming reactive HTTP request
-   * @return a map of condition variables keyed by name
+   * @return the condition variables for the request
    */
-  public static Map<String, Object> build(ServerHttpRequest request) {
+  public static ConditionVariables build(ServerHttpRequest request) {
     Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
     Map<String, String> params = new HashMap<>();

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/condition/ServerHttpConditionVariables.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/condition/ServerHttpConditionVariables.java
@@ -3,6 +3,7 @@ package net.brightroom.featureflag.webflux.condition;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import net.brightroom.featureflag.core.condition.ConditionVariablesBuilder;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 
@@ -24,7 +25,7 @@ public final class ServerHttpConditionVariables {
    * @return a map of condition variables keyed by name
    */
   public static Map<String, Object> build(ServerHttpRequest request) {
-    Map<String, String> headers = new HashMap<>();
+    Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
     Map<String, String> params = new HashMap<>();
     request.getQueryParams().forEach((name, values) -> params.put(name, values.getFirst()));

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,16 +1,13 @@
 package net.brightroom.featureflag.webflux.filter;
 
-import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.Map;
-import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.webflux.condition.ServerHttpConditionVariables;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.reactive.function.server.HandlerFilterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
@@ -46,7 +43,7 @@ public class FeatureFlagHandlerFilterFunction {
   private final ReactiveRolloutStrategy rolloutStrategy;
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
-  private final FeatureFlagConditionEvaluator conditionEvaluator;
+  private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
@@ -129,64 +126,46 @@ public class FeatureFlagHandlerFilterFunction {
                     return resolution.resolve(
                         request, new FeatureFlagAccessDeniedException(featureName));
                   }
-                  if (condition != null && !condition.isEmpty()) {
-                    Map<String, Object> variables =
-                        buildConditionVariables(request.exchange().getRequest());
-                    if (!conditionEvaluator.evaluate(condition, variables)) {
-                      return resolution.resolve(
-                          request, new FeatureFlagAccessDeniedException(featureName));
-                    }
-                  }
-                  return rolloutPercentageProvider
-                      .getRolloutPercentage(featureName)
-                      .defaultIfEmpty(rolloutFallback)
-                      .flatMap(
-                          rollout -> {
-                            if (rollout < 100) {
-                              return contextResolver
-                                  .resolve(request.exchange().getRequest())
-                                  .flatMap(
-                                      ctx ->
-                                          rolloutStrategy
-                                              .isInRollout(featureName, ctx, rollout)
-                                              .flatMap(
-                                                  inRollout -> {
-                                                    if (!inRollout) {
-                                                      return resolution.resolve(
-                                                          request,
-                                                          new FeatureFlagAccessDeniedException(
-                                                              featureName));
-                                                    }
-                                                    return next.handle(request);
-                                                  }))
-                                  .switchIfEmpty(Mono.defer(() -> next.handle(request)));
-                            }
-                            return next.handle(request);
-                          });
+                  Mono<Boolean> conditionMono =
+                      (condition != null && !condition.isEmpty())
+                          ? conditionEvaluator.evaluate(
+                              condition,
+                              ServerHttpConditionVariables.build(request.exchange().getRequest()))
+                          : Mono.just(true);
+                  return conditionMono.flatMap(
+                      conditionPassed -> {
+                        if (!conditionPassed) {
+                          return resolution.resolve(
+                              request, new FeatureFlagAccessDeniedException(featureName));
+                        }
+                        return rolloutPercentageProvider
+                            .getRolloutPercentage(featureName)
+                            .defaultIfEmpty(rolloutFallback)
+                            .flatMap(
+                                rollout -> {
+                                  if (rollout < 100) {
+                                    return contextResolver
+                                        .resolve(request.exchange().getRequest())
+                                        .flatMap(
+                                            ctx ->
+                                                rolloutStrategy
+                                                    .isInRollout(featureName, ctx, rollout)
+                                                    .flatMap(
+                                                        inRollout -> {
+                                                          if (!inRollout) {
+                                                            return resolution.resolve(
+                                                                request,
+                                                                new FeatureFlagAccessDeniedException(
+                                                                    featureName));
+                                                          }
+                                                          return next.handle(request);
+                                                        }))
+                                        .switchIfEmpty(Mono.defer(() -> next.handle(request)));
+                                  }
+                                  return next.handle(request);
+                                });
+                      });
                 });
-  }
-
-  private Map<String, Object> buildConditionVariables(ServerHttpRequest request) {
-    Map<String, Object> variables = new HashMap<>();
-    Map<String, String> headers = new HashMap<>();
-    request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
-    variables.put("headers", headers);
-    Map<String, String> params = new HashMap<>();
-    request.getQueryParams().forEach((name, values) -> params.put(name, values.getFirst()));
-    variables.put("params", params);
-    Map<String, String> cookies = new HashMap<>();
-    request
-        .getCookies()
-        .forEach(
-            (name, cookieList) -> {
-              if (!cookieList.isEmpty()) cookies.put(name, cookieList.getFirst().getValue());
-            });
-    variables.put("cookies", cookies);
-    variables.put("path", request.getPath().value());
-    variables.put("method", request.getMethod().name());
-    InetSocketAddress remoteAddr = request.getRemoteAddress();
-    variables.put("remoteAddress", remoteAddr != null ? remoteAddr.getHostString() : "");
-    return variables;
   }
 
   /**
@@ -198,7 +177,7 @@ public class FeatureFlagHandlerFilterFunction {
    * @param contextResolver the resolver used to extract context from the current request
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature
-   * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions
+   * @param conditionEvaluator the reactive evaluator used to evaluate SpEL condition expressions
    */
   public FeatureFlagHandlerFilterFunction(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
@@ -206,7 +185,7 @@ public class FeatureFlagHandlerFilterFunction {
       ReactiveRolloutStrategy rolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider rolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
     this.reactiveFeatureFlagProvider = reactiveFeatureFlagProvider;
     this.resolution = resolution;
     this.rolloutStrategy = rolloutStrategy;

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,11 +1,16 @@
 package net.brightroom.featureflag.webflux.filter;
 
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.reactive.function.server.HandlerFilterFunction;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
@@ -41,6 +46,7 @@ public class FeatureFlagHandlerFilterFunction {
   private final ReactiveRolloutStrategy rolloutStrategy;
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
+  private final FeatureFlagConditionEvaluator conditionEvaluator;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
@@ -50,16 +56,28 @@ public class FeatureFlagHandlerFilterFunction {
    * @throws IllegalArgumentException if {@code featureName} is null or blank
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(String featureName) {
-    return of(featureName, 100);
+    return of(featureName, "", 100);
+  }
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
+   * and SpEL condition expression.
+   *
+   * @param featureName the name of the feature flag to check; must not be null or blank
+   * @param condition SpEL expression evaluated against request context; empty string means no
+   *     condition
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
+   *     and condition
+   * @throws IllegalArgumentException if {@code featureName} is null or blank
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String featureName, String condition) {
+    return of(featureName, condition, 100);
   }
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
    * and rollout percentage.
-   *
-   * <p>The rollout percentage is resolved from the {@link ReactiveRolloutPercentageProvider} first.
-   * If no rollout percentage is configured in the provider, the {@code rolloutFallback} argument is
-   * used as a fallback.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
@@ -71,6 +89,27 @@ public class FeatureFlagHandlerFilterFunction {
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
       String featureName, int rolloutFallback) {
+    return of(featureName, "", rolloutFallback);
+  }
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag,
+   * SpEL condition expression, and rollout percentage.
+   *
+   * <p>The evaluation order is: feature enabled check → condition check → rollout check.
+   *
+   * @param featureName the name of the feature flag to check; must not be null or blank
+   * @param condition SpEL expression evaluated against request context; empty string means no
+   *     condition
+   * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
+   *     the provider; 100 means fully enabled
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag,
+   *     condition, and rollout
+   * @throws IllegalArgumentException if {@code featureName} is null or blank, or if {@code
+   *     rolloutFallback} is not between 0 and 100
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String featureName, String condition, int rolloutFallback) {
     if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException(
           "featureName must not be null or blank. "
@@ -89,6 +128,14 @@ public class FeatureFlagHandlerFilterFunction {
                   if (!enabled) {
                     return resolution.resolve(
                         request, new FeatureFlagAccessDeniedException(featureName));
+                  }
+                  if (condition != null && !condition.isEmpty()) {
+                    Map<String, Object> variables =
+                        buildConditionVariables(request.exchange().getRequest());
+                    if (!conditionEvaluator.evaluate(condition, variables)) {
+                      return resolution.resolve(
+                          request, new FeatureFlagAccessDeniedException(featureName));
+                    }
                   }
                   return rolloutPercentageProvider
                       .getRolloutPercentage(featureName)
@@ -119,6 +166,29 @@ public class FeatureFlagHandlerFilterFunction {
                 });
   }
 
+  private Map<String, Object> buildConditionVariables(ServerHttpRequest request) {
+    Map<String, Object> variables = new HashMap<>();
+    Map<String, String> headers = new HashMap<>();
+    request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
+    variables.put("headers", headers);
+    Map<String, String> params = new HashMap<>();
+    request.getQueryParams().forEach((name, values) -> params.put(name, values.getFirst()));
+    variables.put("params", params);
+    Map<String, String> cookies = new HashMap<>();
+    request
+        .getCookies()
+        .forEach(
+            (name, cookieList) -> {
+              if (!cookieList.isEmpty()) cookies.put(name, cookieList.getFirst().getValue());
+            });
+    variables.put("cookies", cookies);
+    variables.put("path", request.getPath().value());
+    variables.put("method", request.getMethod().name());
+    InetSocketAddress remoteAddr = request.getRemoteAddress();
+    variables.put("remoteAddress", remoteAddr != null ? remoteAddr.getHostString() : "");
+    return variables;
+  }
+
   /**
    * Creates a new {@code FeatureFlagHandlerFilterFunction}.
    *
@@ -128,17 +198,20 @@ public class FeatureFlagHandlerFilterFunction {
    * @param contextResolver the resolver used to extract context from the current request
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature
+   * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions
    */
   public FeatureFlagHandlerFilterFunction(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
       AccessDeniedHandlerFilterResolution resolution,
       ReactiveRolloutStrategy rolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
-      ReactiveRolloutPercentageProvider rolloutPercentageProvider) {
+      ReactiveRolloutPercentageProvider rolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     this.reactiveFeatureFlagProvider = reactiveFeatureFlagProvider;
     this.resolution = resolution;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionEvaluator = conditionEvaluator;
   }
 }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,6 +1,7 @@
 package net.brightroom.featureflag.webflux.filter;
 
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
@@ -9,6 +10,8 @@ import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextReso
 import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
 import org.springframework.web.reactive.function.server.HandlerFilterFunction;
+import org.springframework.web.reactive.function.server.HandlerFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
@@ -116,56 +119,111 @@ public class FeatureFlagHandlerFilterFunction {
       throw new IllegalArgumentException(
           "rollout must be between 0 and 100, but was: " + rolloutFallback);
     }
-    return (request, next) ->
-        reactiveFeatureFlagProvider
-            .isFeatureEnabled(featureName)
-            .defaultIfEmpty(false)
-            .flatMap(
-                enabled -> {
-                  if (!enabled) {
-                    return resolution.resolve(
-                        request, new FeatureFlagAccessDeniedException(featureName));
-                  }
-                  Mono<Boolean> conditionMono =
-                      (condition != null && !condition.isEmpty())
-                          ? conditionEvaluator.evaluate(
-                              condition,
-                              ServerHttpConditionVariables.build(request.exchange().getRequest()))
-                          : Mono.just(true);
-                  return conditionMono.flatMap(
-                      conditionPassed -> {
-                        if (!conditionPassed) {
-                          return resolution.resolve(
-                              request, new FeatureFlagAccessDeniedException(featureName));
-                        }
-                        return rolloutPercentageProvider
-                            .getRolloutPercentage(featureName)
-                            .defaultIfEmpty(rolloutFallback)
-                            .flatMap(
-                                rollout -> {
-                                  if (rollout < 100) {
-                                    return contextResolver
-                                        .resolve(request.exchange().getRequest())
-                                        .flatMap(
-                                            ctx ->
-                                                rolloutStrategy
-                                                    .isInRollout(featureName, ctx, rollout)
-                                                    .flatMap(
-                                                        inRollout -> {
-                                                          if (!inRollout) {
-                                                            return resolution.resolve(
-                                                                request,
-                                                                new FeatureFlagAccessDeniedException(
-                                                                    featureName));
-                                                          }
-                                                          return next.handle(request);
-                                                        }))
-                                        .switchIfEmpty(Mono.defer(() -> next.handle(request)));
-                                  }
-                                  return next.handle(request);
-                                });
-                      });
-                });
+    return (request, next) -> filter(request, next, featureName, condition, rolloutFallback);
+  }
+
+  private Mono<ServerResponse> filter(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      String condition,
+      int rolloutFallback) {
+    return reactiveFeatureFlagProvider
+        .isFeatureEnabled(featureName)
+        .defaultIfEmpty(false)
+        .flatMap(
+            enabled ->
+                handleEnabled(request, next, featureName, condition, rolloutFallback, enabled));
+  }
+
+  private Mono<ServerResponse> handleEnabled(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      String condition,
+      int rolloutFallback,
+      boolean enabled) {
+    if (!enabled) {
+      return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
+    }
+    return evaluateCondition(request, next, featureName, condition, rolloutFallback);
+  }
+
+  private Mono<ServerResponse> evaluateCondition(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      String condition,
+      int rolloutFallback) {
+    Mono<Boolean> conditionMono;
+    if (condition != null && !condition.isEmpty()) {
+      conditionMono =
+          conditionEvaluator.evaluate(
+              condition, ServerHttpConditionVariables.build(request.exchange().getRequest()));
+    } else {
+      conditionMono = Mono.just(true);
+    }
+    return conditionMono.flatMap(
+        passed -> handleConditionResult(request, next, featureName, rolloutFallback, passed));
+  }
+
+  private Mono<ServerResponse> handleConditionResult(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      int rolloutFallback,
+      boolean passed) {
+    if (!passed) {
+      return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
+    }
+    return applyRollout(request, next, featureName, rolloutFallback);
+  }
+
+  private Mono<ServerResponse> applyRollout(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      int rolloutFallback) {
+    return rolloutPercentageProvider
+        .getRolloutPercentage(featureName)
+        .defaultIfEmpty(rolloutFallback)
+        .flatMap(rollout -> handleRollout(request, next, featureName, rollout));
+  }
+
+  private Mono<ServerResponse> handleRollout(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      int rollout) {
+    if (rollout >= 100) {
+      return next.handle(request);
+    }
+    return contextResolver
+        .resolve(request.exchange().getRequest())
+        .flatMap(ctx -> checkInRollout(request, next, featureName, ctx, rollout))
+        .switchIfEmpty(Mono.defer(() -> next.handle(request)));
+  }
+
+  private Mono<ServerResponse> checkInRollout(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      FeatureFlagContext ctx,
+      int rollout) {
+    return rolloutStrategy
+        .isInRollout(featureName, ctx, rollout)
+        .flatMap(inRollout -> handleRolloutResult(request, next, featureName, inRollout));
+  }
+
+  private Mono<ServerResponse> handleRolloutResult(
+      ServerRequest request,
+      HandlerFunction<ServerResponse> next,
+      String featureName,
+      boolean inRollout) {
+    if (!inRollout) {
+      return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
+    }
+    return next.handle(request);
   }
 
   /**

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
-import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
@@ -19,7 +19,10 @@ import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -33,8 +36,8 @@ class FeatureFlagAspectTest {
   // Default: no rollout percentage configured in provider, falls back to annotation value
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
       mock(ReactiveRolloutPercentageProvider.class, invocation -> Mono.empty());
-  private final FeatureFlagConditionEvaluator conditionEvaluator =
-      mock(FeatureFlagConditionEvaluator.class);
+  private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator =
+      mock(ReactiveFeatureFlagConditionEvaluator.class);
   private final FeatureFlagAspect aspect =
       new FeatureFlagAspect(
           provider,
@@ -82,6 +85,16 @@ class FeatureFlagAspectTest {
 
     @FeatureFlag(value = "some-feature", rollout = 50)
     public Flux<String> rolloutFluxMethod() {
+      return Flux.just("result1", "result2");
+    }
+
+    @FeatureFlag(value = "some-feature", condition = "headers['X-Beta'] != null")
+    public Mono<String> conditionMonoMethod() {
+      return Mono.just("result");
+    }
+
+    @FeatureFlag(value = "some-feature", condition = "headers['X-Beta'] != null")
+    public Flux<String> conditionFluxMethod() {
       return Flux.just("result1", "result2");
     }
 
@@ -461,6 +474,168 @@ class FeatureFlagAspectTest {
                 e instanceof FeatureFlagAccessDeniedException
                     && ((FeatureFlagAccessDeniedException) e).featureName().equals("some-feature"))
         .verify();
+  }
+
+  // --- condition ---
+
+  private void stubRequestForConditionVariables(ServerHttpRequest httpRequest) {
+    when(httpRequest.getHeaders()).thenReturn(new HttpHeaders());
+    when(httpRequest.getQueryParams()).thenReturn(new LinkedMultiValueMap<>());
+    when(httpRequest.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+    org.springframework.http.server.RequestPath path =
+        mock(org.springframework.http.server.RequestPath.class);
+    when(path.value()).thenReturn("/test");
+    when(httpRequest.getPath()).thenReturn(path);
+    when(httpRequest.getMethod()).thenReturn(HttpMethod.GET);
+    when(httpRequest.getRemoteAddress()).thenReturn(null);
+  }
+
+  @Test
+  void checkFeatureFlag_returnsMono_whenConditionIsTrue() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionMonoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(true));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Mono<String> mono = (Mono<String>) result;
+    StepVerifier.create(mono.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkFeatureFlag_returnsMonoError_whenConditionIsFalse() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionMonoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(false));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    StepVerifier.create(
+            ((Mono<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof FeatureFlagAccessDeniedException
+                    && ((FeatureFlagAccessDeniedException) e).featureName().equals("some-feature"))
+        .verify();
+  }
+
+  @Test
+  void checkFeatureFlag_returnsFlux_whenConditionIsTrue() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionFluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(true));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Flux<String> flux = (Flux<String>) result;
+    StepVerifier.create(flux.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result1", "result2")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkFeatureFlag_returnsFluxError_whenConditionIsFalse() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionFluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(false));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    StepVerifier.create(
+            ((Flux<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof FeatureFlagAccessDeniedException
+                    && ((FeatureFlagAccessDeniedException) e).featureName().equals("some-feature"))
+        .verify();
+  }
+
+  @Test
+  void checkFeatureFlag_skipsConditionCheck_whenConditionIsEmpty() throws Throwable {
+    // monoMethod() has no condition attribute — evaluator must not be called
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Mono<Object> mono = (Mono<Object>) result;
+    StepVerifier.create(mono).expectNextCount(1).verifyComplete();
+    verifyNoInteractions(conditionEvaluator);
   }
 
   @Test

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
@@ -32,17 +33,25 @@ class FeatureFlagAspectTest {
   // Default: no rollout percentage configured in provider, falls back to annotation value
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
       mock(ReactiveRolloutPercentageProvider.class, invocation -> Mono.empty());
+  private final FeatureFlagConditionEvaluator conditionEvaluator =
+      mock(FeatureFlagConditionEvaluator.class);
   private final FeatureFlagAspect aspect =
       new FeatureFlagAspect(
           provider,
           new DefaultReactiveRolloutStrategy(),
           contextResolver,
-          rolloutPercentageProvider);
+          rolloutPercentageProvider,
+          conditionEvaluator);
 
   // Aspect with mocked rollout strategy for rollout-specific tests
   private final ReactiveRolloutStrategy rolloutStrategy = mock(ReactiveRolloutStrategy.class);
   private final FeatureFlagAspect aspectWithRollout =
-      new FeatureFlagAspect(provider, rolloutStrategy, contextResolver, rolloutPercentageProvider);
+      new FeatureFlagAspect(
+          provider,
+          rolloutStrategy,
+          contextResolver,
+          rolloutPercentageProvider,
+          conditionEvaluator);
 
   static class TestController {
 

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
@@ -18,7 +18,10 @@ import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedH
 import net.brightroom.featureflag.webflux.rollout.DefaultReactiveRolloutStrategy;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.reactive.function.server.HandlerFilterFunction;
 import org.springframework.web.reactive.function.server.HandlerFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
@@ -36,8 +39,8 @@ class FeatureFlagHandlerFilterFunctionTest {
       mock(ReactiveFeatureFlagContextResolver.class);
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
       mock(ReactiveRolloutPercentageProvider.class);
-  private final FeatureFlagConditionEvaluator conditionEvaluator =
-      mock(FeatureFlagConditionEvaluator.class);
+  private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator =
+      mock(ReactiveFeatureFlagConditionEvaluator.class);
   private final FeatureFlagHandlerFilterFunction filterFunction =
       new FeatureFlagHandlerFilterFunction(
           provider,
@@ -177,6 +180,123 @@ class FeatureFlagHandlerFilterFunctionTest {
 
     verifyNoInteractions(next);
     verify(resolution).resolve(eq(request), any(FeatureFlagAccessDeniedException.class));
+  }
+
+  private void stubRequestForConditionVariables(ServerHttpRequest httpRequest) {
+    when(httpRequest.getHeaders()).thenReturn(new HttpHeaders());
+    when(httpRequest.getQueryParams()).thenReturn(new LinkedMultiValueMap<>());
+    when(httpRequest.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+    org.springframework.http.server.RequestPath path =
+        mock(org.springframework.http.server.RequestPath.class);
+    when(path.value()).thenReturn("/functional/condition/header");
+    when(httpRequest.getPath()).thenReturn(path);
+    when(httpRequest.getMethod()).thenReturn(HttpMethod.GET);
+    when(httpRequest.getRemoteAddress()).thenReturn(null);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenConditionPasses() {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature")).thenReturn(Mono.empty());
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.exchange()).thenReturn(exchange);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any()))
+        .thenReturn(Mono.just(true));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunction.of("my-feature", "headers['X-Beta'] != null");
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenConditionFails() {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(Mono.just(true));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.exchange()).thenReturn(exchange);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any()))
+        .thenReturn(Mono.just(false));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(FeatureFlagAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunction.of("my-feature", "headers['X-Beta'] != null");
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(next);
+    verify(resolution).resolve(eq(request), any(FeatureFlagAccessDeniedException.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_skipsConditionCheck_whenConditionIsEmpty() {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature")).thenReturn(Mono.empty());
+
+    ServerRequest request = mock(ServerRequest.class);
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-feature");
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verifyNoInteractions(conditionEvaluator);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_evaluatesConditionBeforeRollout() {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(Mono.just(true));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.exchange()).thenReturn(exchange);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any()))
+        .thenReturn(Mono.just(false));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(FeatureFlagAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    // rollout = 50, but condition fails first — rollout check must not be reached
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-feature", "headers['X-Beta'] != null", 50);
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(rolloutPercentageProvider);
+    verifyNoInteractions(contextResolver);
   }
 
   @Test

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
@@ -35,19 +36,27 @@ class FeatureFlagHandlerFilterFunctionTest {
       mock(ReactiveFeatureFlagContextResolver.class);
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
       mock(ReactiveRolloutPercentageProvider.class);
+  private final FeatureFlagConditionEvaluator conditionEvaluator =
+      mock(FeatureFlagConditionEvaluator.class);
   private final FeatureFlagHandlerFilterFunction filterFunction =
       new FeatureFlagHandlerFilterFunction(
           provider,
           resolution,
           new DefaultReactiveRolloutStrategy(),
           contextResolver,
-          rolloutPercentageProvider);
+          rolloutPercentageProvider,
+          conditionEvaluator);
 
   // Filter function with mocked rollout strategy for rollout-specific tests
   private final ReactiveRolloutStrategy rolloutStrategy = mock(ReactiveRolloutStrategy.class);
   private final FeatureFlagHandlerFilterFunction filterFunctionWithRollout =
       new FeatureFlagHandlerFilterFunction(
-          provider, resolution, rolloutStrategy, contextResolver, rolloutPercentageProvider);
+          provider,
+          resolution,
+          rolloutStrategy,
+          contextResolver,
+          rolloutPercentageProvider,
+          conditionEvaluator);
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagHandlerFilterFunctionConditionIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagHandlerFilterFunctionConditionIntegrationTest.java
@@ -1,0 +1,57 @@
+package net.brightroom.featureflag.webmvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.brightroom.featureflag.webmvc.configuration.FeatureFlagMvcTestAutoConfiguration;
+import net.brightroom.featureflag.webmvc.endpoint.FeatureFlagRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest
+@Import({FeatureFlagMvcTestAutoConfiguration.class, FeatureFlagRouterConfiguration.class})
+@TestPropertySource(
+    properties = {
+      "feature-flags.features.conditional-feature.enabled=true",
+    })
+class FeatureFlagHandlerFilterFunctionConditionIntegrationTest {
+
+  MockMvc mockMvc;
+
+  @Test
+  void shouldAllowAccess_whenHeaderConditionIsSatisfied() throws Exception {
+    mockMvc
+        .perform(get("/functional/condition/header").header("X-Beta", "true"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+
+  @Test
+  void shouldBlockAccess_whenHeaderConditionIsNotSatisfied() throws Exception {
+    mockMvc
+        .perform(get("/functional/condition/header"))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            content()
+                .json(
+                    """
+                  {
+                    "detail" : "Feature 'conditional-feature' is not available",
+                    "instance" : "/functional/condition/header",
+                    "status" : 403,
+                    "title" : "Feature flag access denied",
+                    "type" : "https://github.com/bright-room/feature-flag-spring-boot-starter#response-types"
+                  }
+                  """));
+  }
+
+  @Autowired
+  FeatureFlagHandlerFilterFunctionConditionIntegrationTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+}

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @TestPropertySource(
     properties = {
       "feature-flags.features.conditional-feature.enabled=true",
+      "feature-flags.features.conditional-feature.rollout=100",
     })
 class FeatureFlagInterceptorConditionIntegrationTest {
 
@@ -68,6 +69,22 @@ class FeatureFlagInterceptorConditionIntegrationTest {
   @Test
   void shouldBlockAccess_whenParamIsMissing() throws Exception {
     mockMvc.perform(get("/condition/param")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldBlockAccess_onConditionWithRollout_whenConditionIsNotSatisfied() throws Exception {
+    // condition fails (no X-Beta header) — access denied regardless of rollout
+    mockMvc.perform(get("/condition/with-rollout")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldAllowAccess_onConditionWithRollout_whenConditionSatisfiedAndRolloutFull()
+      throws Exception {
+    // rollout overridden to 100% via property, condition satisfied
+    mockMvc
+        .perform(get("/condition/with-rollout").header("X-Beta", "true"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
   }
 
   @Autowired

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
@@ -1,0 +1,77 @@
+package net.brightroom.featureflag.webmvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.brightroom.featureflag.webmvc.configuration.FeatureFlagMvcTestAutoConfiguration;
+import net.brightroom.featureflag.webmvc.endpoint.FeatureFlagConditionController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = FeatureFlagConditionController.class)
+@Import(FeatureFlagMvcTestAutoConfiguration.class)
+@TestPropertySource(
+    properties = {
+      "feature-flags.features.conditional-feature.enabled=true",
+    })
+class FeatureFlagInterceptorConditionIntegrationTest {
+
+  MockMvc mockMvc;
+
+  @Test
+  void shouldAllowAccess_whenHeaderConditionIsSatisfied() throws Exception {
+    mockMvc
+        .perform(get("/condition/header").header("X-Beta", "true"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+
+  @Test
+  void shouldBlockAccess_whenHeaderConditionIsNotSatisfied() throws Exception {
+    mockMvc
+        .perform(get("/condition/header"))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            content()
+                .json(
+                    """
+                  {
+                    "detail" : "Feature 'conditional-feature' is not available",
+                    "instance" : "/condition/header",
+                    "status" : 403,
+                    "title" : "Feature flag access denied",
+                    "type" : "https://github.com/bright-room/feature-flag-spring-boot-starter#response-types"
+                  }
+                  """));
+  }
+
+  @Test
+  void shouldAllowAccess_whenParamConditionIsSatisfied() throws Exception {
+    mockMvc
+        .perform(get("/condition/param").param("variant", "B"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamConditionIsNotSatisfied() throws Exception {
+    mockMvc
+        .perform(get("/condition/param").param("variant", "A"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamIsMissing() throws Exception {
+    mockMvc.perform(get("/condition/param")).andExpect(status().isForbidden());
+  }
+
+  @Autowired
+  FeatureFlagInterceptorConditionIntegrationTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+}

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
@@ -87,6 +87,15 @@ class FeatureFlagInterceptorConditionIntegrationTest {
         .andExpect(content().string("Allowed"));
   }
 
+  @Test
+  void shouldAllowAccess_whenRemoteAddressConditionIsSatisfied() throws Exception {
+    // MockMvc defaults remoteAddr to 127.0.0.1
+    mockMvc
+        .perform(get("/condition/remote-address"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+
   @Autowired
   FeatureFlagInterceptorConditionIntegrationTest(MockMvc mockMvc) {
     this.mockMvc = mockMvc;

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagConditionController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagConditionController.java
@@ -1,0 +1,29 @@
+package net.brightroom.featureflag.webmvc.endpoint;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FeatureFlagConditionController {
+
+  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null")
+  @GetMapping("/condition/header")
+  String headerCondition() {
+    return "Allowed";
+  }
+
+  @FeatureFlag(value = "conditional-feature", condition = "params['variant'] == 'B'")
+  @GetMapping("/condition/param")
+  String paramCondition() {
+    return "Allowed";
+  }
+
+  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null", rollout = 50)
+  @GetMapping("/condition/with-rollout")
+  String conditionWithRollout() {
+    return "Allowed";
+  }
+
+  public FeatureFlagConditionController() {}
+}

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagConditionController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagConditionController.java
@@ -25,5 +25,11 @@ public class FeatureFlagConditionController {
     return "Allowed";
   }
 
+  @FeatureFlag(value = "conditional-feature", condition = "remoteAddress == '127.0.0.1'")
+  @GetMapping("/condition/remote-address")
+  String remoteAddressCondition() {
+    return "Allowed";
+  }
+
   public FeatureFlagConditionController() {}
 }

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagRouterConfiguration.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagRouterConfiguration.java
@@ -62,6 +62,14 @@ public class FeatureFlagRouterConfiguration {
         .build();
   }
 
+  @Bean
+  RouterFunction<ServerResponse> functionalConditionRoute() {
+    return route()
+        .GET("/functional/condition/header", req -> ServerResponse.ok().body("Allowed"))
+        .filter(featureFlagFilter.of("conditional-feature", "headers['X-Beta'] != null"))
+        .build();
+  }
+
   public FeatureFlagRouterConfiguration(FeatureFlagHandlerFilterFunction featureFlagFilter) {
     this.featureFlagFilter = featureFlagFilter;
   }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
@@ -1,6 +1,8 @@
 package net.brightroom.featureflag.webmvc.autoconfigure;
 
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
+import net.brightroom.featureflag.core.condition.SpelFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.InMemoryFeatureFlagProvider;
@@ -70,13 +72,24 @@ public class FeatureFlagMvcAutoConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean
+  FeatureFlagConditionEvaluator featureFlagConditionEvaluator() {
+    return new SpelFeatureFlagConditionEvaluator(featureFlagProperties.condition().failOnError());
+  }
+
+  @Bean
   FeatureFlagInterceptor featureFlagInterceptor(
       FeatureFlagProvider featureFlagProvider,
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
-      RolloutPercentageProvider rolloutPercentageProvider) {
+      RolloutPercentageProvider rolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     return new FeatureFlagInterceptor(
-        featureFlagProvider, rolloutStrategy, contextResolver, rolloutPercentageProvider);
+        featureFlagProvider,
+        rolloutStrategy,
+        contextResolver,
+        rolloutPercentageProvider,
+        conditionEvaluator);
   }
 
   @Bean
@@ -98,13 +111,15 @@ public class FeatureFlagMvcAutoConfiguration {
       AccessDeniedHandlerFilterResolution accessDeniedHandlerFilterResolution,
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
-      RolloutPercentageProvider rolloutPercentageProvider) {
+      RolloutPercentageProvider rolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     return new FeatureFlagHandlerFilterFunction(
         featureFlagProvider,
         accessDeniedHandlerFilterResolution,
         rolloutStrategy,
         contextResolver,
-        rolloutPercentageProvider);
+        rolloutPercentageProvider,
+        conditionEvaluator);
   }
 
   /**

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/condition/HttpServletConditionVariables.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/condition/HttpServletConditionVariables.java
@@ -1,0 +1,46 @@
+package net.brightroom.featureflag.webmvc.condition;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.brightroom.featureflag.core.condition.ConditionVariablesBuilder;
+
+/**
+ * Utility for building the condition variables map from an {@link HttpServletRequest}.
+ *
+ * <p>Shared by {@link net.brightroom.featureflag.webmvc.interceptor.FeatureFlagInterceptor} and
+ * {@link net.brightroom.featureflag.webmvc.filter.FeatureFlagHandlerFilterFunction} to avoid
+ * duplication. Key names are defined by {@link ConditionVariablesBuilder}.
+ */
+public final class HttpServletConditionVariables {
+
+  private HttpServletConditionVariables() {}
+
+  /**
+   * Builds the condition variables map from the given request.
+   *
+   * @param request the incoming HTTP servlet request
+   * @return a map of condition variables keyed by name
+   */
+  public static Map<String, Object> build(HttpServletRequest request) {
+    Map<String, String> headers = new HashMap<>();
+    Collections.list(request.getHeaderNames())
+        .forEach(name -> headers.put(name, request.getHeader(name)));
+    Map<String, String> params = new HashMap<>();
+    request.getParameterMap().forEach((k, v) -> params.put(k, v.length > 0 ? v[0] : ""));
+    Map<String, String> cookies = new HashMap<>();
+    if (request.getCookies() != null) {
+      Arrays.stream(request.getCookies()).forEach(c -> cookies.put(c.getName(), c.getValue()));
+    }
+    return new ConditionVariablesBuilder()
+        .headers(headers)
+        .params(params)
+        .cookies(cookies)
+        .path(request.getRequestURI())
+        .method(request.getMethod())
+        .remoteAddress(request.getRemoteAddr())
+        .build();
+  }
+}

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/condition/HttpServletConditionVariables.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/condition/HttpServletConditionVariables.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import net.brightroom.featureflag.core.condition.ConditionVariablesBuilder;
 
 /**
@@ -25,7 +26,7 @@ public final class HttpServletConditionVariables {
    * @return a map of condition variables keyed by name
    */
   public static Map<String, Object> build(HttpServletRequest request) {
-    Map<String, String> headers = new HashMap<>();
+    Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     Collections.list(request.getHeaderNames())
         .forEach(name -> headers.put(name, request.getHeader(name)));
     Map<String, String> params = new HashMap<>();

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/condition/HttpServletConditionVariables.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/condition/HttpServletConditionVariables.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import net.brightroom.featureflag.core.condition.ConditionVariables;
 import net.brightroom.featureflag.core.condition.ConditionVariablesBuilder;
 
 /**
@@ -20,17 +21,26 @@ public final class HttpServletConditionVariables {
   private HttpServletConditionVariables() {}
 
   /**
-   * Builds the condition variables map from the given request.
+   * Builds the condition variables from the given request.
    *
    * @param request the incoming HTTP servlet request
-   * @return a map of condition variables keyed by name
+   * @return the condition variables for the request
    */
-  public static Map<String, Object> build(HttpServletRequest request) {
+  public static ConditionVariables build(HttpServletRequest request) {
     Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     Collections.list(request.getHeaderNames())
         .forEach(name -> headers.put(name, request.getHeader(name)));
     Map<String, String> params = new HashMap<>();
-    request.getParameterMap().forEach((k, v) -> params.put(k, v.length > 0 ? v[0] : ""));
+    request
+        .getParameterMap()
+        .forEach(
+            (k, v) -> {
+              if (v.length > 0) {
+                params.put(k, v[0]);
+              } else {
+                params.put(k, "");
+              }
+            });
     Map<String, String> cookies = new HashMap<>();
     if (request.getCookies() != null) {
       Arrays.stream(request.getCookies()).forEach(c -> cookies.put(c.getName(), c.getValue()));

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,9 +1,5 @@
 package net.brightroom.featureflag.webmvc.filter;
 
-import jakarta.servlet.http.HttpServletRequest;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
@@ -12,6 +8,7 @@ import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedExceptio
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
+import net.brightroom.featureflag.webmvc.condition.HttpServletConditionVariables;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
 import net.brightroom.featureflag.webmvc.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
 import org.springframework.web.servlet.function.HandlerFilterFunction;
@@ -126,7 +123,8 @@ public class FeatureFlagHandlerFilterFunction {
         return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
       }
       if (condition != null && !condition.isEmpty()) {
-        Map<String, Object> variables = buildConditionVariables(request.servletRequest());
+        Map<String, Object> variables =
+            HttpServletConditionVariables.build(request.servletRequest());
         if (!conditionEvaluator.evaluate(condition, variables)) {
           return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
         }
@@ -141,26 +139,6 @@ public class FeatureFlagHandlerFilterFunction {
       }
       return next.handle(request);
     };
-  }
-
-  private Map<String, Object> buildConditionVariables(HttpServletRequest request) {
-    Map<String, Object> variables = new HashMap<>();
-    Map<String, String> headers = new HashMap<>();
-    Collections.list(request.getHeaderNames())
-        .forEach(name -> headers.put(name, request.getHeader(name)));
-    variables.put("headers", headers);
-    Map<String, String> params = new HashMap<>();
-    request.getParameterMap().forEach((k, v) -> params.put(k, v.length > 0 ? v[0] : ""));
-    variables.put("params", params);
-    Map<String, String> cookies = new HashMap<>();
-    if (request.getCookies() != null) {
-      Arrays.stream(request.getCookies()).forEach(c -> cookies.put(c.getName(), c.getValue()));
-    }
-    variables.put("cookies", cookies);
-    variables.put("path", request.getRequestURI());
-    variables.put("method", request.getMethod());
-    variables.put("remoteAddress", request.getRemoteAddr());
-    return variables;
   }
 
   /**

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,6 +1,12 @@
 package net.brightroom.featureflag.webmvc.filter;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -42,6 +48,7 @@ public class FeatureFlagHandlerFilterFunction {
   private final RolloutStrategy rolloutStrategy;
   private final FeatureFlagContextResolver contextResolver;
   private final RolloutPercentageProvider rolloutPercentageProvider;
+  private final FeatureFlagConditionEvaluator conditionEvaluator;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
@@ -51,16 +58,28 @@ public class FeatureFlagHandlerFilterFunction {
    * @throws IllegalArgumentException if {@code featureName} is null or blank
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(String featureName) {
-    return of(featureName, 100);
+    return of(featureName, "", 100);
+  }
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
+   * and SpEL condition expression.
+   *
+   * @param featureName the name of the feature flag to check; must not be null or blank
+   * @param condition SpEL expression evaluated against request context; empty string means no
+   *     condition
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
+   *     and condition
+   * @throws IllegalArgumentException if {@code featureName} is null or blank
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String featureName, String condition) {
+    return of(featureName, condition, 100);
   }
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
    * and rollout percentage.
-   *
-   * <p>The rollout percentage is resolved from the {@link RolloutPercentageProvider} first. If no
-   * rollout percentage is configured in the provider, the {@code rolloutFallback} argument is used
-   * as a fallback.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
@@ -72,6 +91,27 @@ public class FeatureFlagHandlerFilterFunction {
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
       String featureName, int rolloutFallback) {
+    return of(featureName, "", rolloutFallback);
+  }
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag,
+   * SpEL condition expression, and rollout percentage.
+   *
+   * <p>The evaluation order is: feature enabled check → condition check → rollout check.
+   *
+   * @param featureName the name of the feature flag to check; must not be null or blank
+   * @param condition SpEL expression evaluated against request context; empty string means no
+   *     condition
+   * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
+   *     the provider; 100 means fully enabled
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag,
+   *     condition, and rollout
+   * @throws IllegalArgumentException if {@code featureName} is null or blank, or if {@code
+   *     rolloutFallback} is not between 0 and 100
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String featureName, String condition, int rolloutFallback) {
     if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException(
           "featureName must not be null or blank. "
@@ -85,6 +125,12 @@ public class FeatureFlagHandlerFilterFunction {
       if (!featureFlagProvider.isFeatureEnabled(featureName)) {
         return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
       }
+      if (condition != null && !condition.isEmpty()) {
+        Map<String, Object> variables = buildConditionVariables(request.servletRequest());
+        if (!conditionEvaluator.evaluate(condition, variables)) {
+          return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
+        }
+      }
       int rollout =
           rolloutPercentageProvider.getRolloutPercentage(featureName).orElse(rolloutFallback);
       if (rollout < 100) {
@@ -95,6 +141,26 @@ public class FeatureFlagHandlerFilterFunction {
       }
       return next.handle(request);
     };
+  }
+
+  private Map<String, Object> buildConditionVariables(HttpServletRequest request) {
+    Map<String, Object> variables = new HashMap<>();
+    Map<String, String> headers = new HashMap<>();
+    Collections.list(request.getHeaderNames())
+        .forEach(name -> headers.put(name, request.getHeader(name)));
+    variables.put("headers", headers);
+    Map<String, String> params = new HashMap<>();
+    request.getParameterMap().forEach((k, v) -> params.put(k, v.length > 0 ? v[0] : ""));
+    variables.put("params", params);
+    Map<String, String> cookies = new HashMap<>();
+    if (request.getCookies() != null) {
+      Arrays.stream(request.getCookies()).forEach(c -> cookies.put(c.getName(), c.getValue()));
+    }
+    variables.put("cookies", cookies);
+    variables.put("path", request.getRequestURI());
+    variables.put("method", request.getMethod());
+    variables.put("remoteAddress", request.getRemoteAddr());
+    return variables;
   }
 
   /**
@@ -109,17 +175,21 @@ public class FeatureFlagHandlerFilterFunction {
    *     must not be null
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature; must not be null
+   * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions; must not
+   *     be null
    */
   public FeatureFlagHandlerFilterFunction(
       FeatureFlagProvider featureFlagProvider,
       AccessDeniedHandlerFilterResolution resolution,
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
-      RolloutPercentageProvider rolloutPercentageProvider) {
+      RolloutPercentageProvider rolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     this.featureFlagProvider = featureFlagProvider;
     this.resolution = resolution;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionEvaluator = conditionEvaluator;
   }
 }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,7 +1,7 @@
 package net.brightroom.featureflag.webmvc.filter;
 
-import java.util.Map;
 import java.util.Optional;
+import net.brightroom.featureflag.core.condition.ConditionVariables;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
@@ -123,7 +123,7 @@ public class FeatureFlagHandlerFilterFunction {
         return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
       }
       if (condition != null && !condition.isEmpty()) {
-        Map<String, Object> variables =
+        ConditionVariables variables =
             HttpServletConditionVariables.build(request.servletRequest());
         if (!conditionEvaluator.evaluate(condition, variables)) {
           return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
@@ -2,8 +2,13 @@ package net.brightroom.featureflag.webmvc.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -28,6 +33,7 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
   private final RolloutStrategy rolloutStrategy;
   private final FeatureFlagContextResolver contextResolver;
   private final RolloutPercentageProvider rolloutPercentageProvider;
+  private final FeatureFlagConditionEvaluator conditionEvaluator;
 
   /**
    * Creates a new {@link FeatureFlagInterceptor}.
@@ -40,16 +46,20 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
    *     must not be null
    * @param rolloutPercentageProvider the provider that supplies per-flag rollout percentages,
    *     overriding annotation-level values when present; must not be null
+   * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions; must not
+   *     be null
    */
   public FeatureFlagInterceptor(
       FeatureFlagProvider featureFlagProvider,
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
-      RolloutPercentageProvider rolloutPercentageProvider) {
+      RolloutPercentageProvider rolloutPercentageProvider,
+      FeatureFlagConditionEvaluator conditionEvaluator) {
     this.featureFlagProvider = featureFlagProvider;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionEvaluator = conditionEvaluator;
   }
 
   @Override
@@ -67,6 +77,7 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
       if (checkFeatureFlag(methodAnnotation)) {
         throw new FeatureFlagAccessDeniedException(methodAnnotation.value());
       }
+      checkCondition(request, methodAnnotation);
       checkRollout(request, methodAnnotation);
       return true;
     }
@@ -79,6 +90,7 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
     if (checkFeatureFlag(classAnnotation)) {
       throw new FeatureFlagAccessDeniedException(classAnnotation.value());
     }
+    checkCondition(request, classAnnotation);
     checkRollout(request, classAnnotation);
 
     return true;
@@ -98,6 +110,37 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
 
   private boolean checkFeatureFlag(FeatureFlag annotation) {
     return !featureFlagProvider.isFeatureEnabled(annotation.value());
+  }
+
+  private void checkCondition(HttpServletRequest request, FeatureFlag annotation) {
+    String condition = annotation.condition();
+    if (condition.isEmpty()) {
+      return;
+    }
+    Map<String, Object> variables = buildConditionVariables(request);
+    if (!conditionEvaluator.evaluate(condition, variables)) {
+      throw new FeatureFlagAccessDeniedException(annotation.value());
+    }
+  }
+
+  private Map<String, Object> buildConditionVariables(HttpServletRequest request) {
+    Map<String, Object> variables = new HashMap<>();
+    Map<String, String> headers = new HashMap<>();
+    Collections.list(request.getHeaderNames())
+        .forEach(name -> headers.put(name, request.getHeader(name)));
+    variables.put("headers", headers);
+    Map<String, String> params = new HashMap<>();
+    request.getParameterMap().forEach((k, v) -> params.put(k, v.length > 0 ? v[0] : ""));
+    variables.put("params", params);
+    Map<String, String> cookies = new HashMap<>();
+    if (request.getCookies() != null) {
+      Arrays.stream(request.getCookies()).forEach(c -> cookies.put(c.getName(), c.getValue()));
+    }
+    variables.put("cookies", cookies);
+    variables.put("path", request.getRequestURI());
+    variables.put("method", request.getMethod());
+    variables.put("remoteAddress", request.getRemoteAddr());
+    return variables;
   }
 
   private void checkRollout(HttpServletRequest request, FeatureFlag annotation) {

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
@@ -2,9 +2,6 @@ package net.brightroom.featureflag.webmvc.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
@@ -14,6 +11,7 @@ import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedExceptio
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
+import net.brightroom.featureflag.webmvc.condition.HttpServletConditionVariables;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
 import org.jspecify.annotations.NonNull;
 import org.springframework.web.method.HandlerMethod;
@@ -117,30 +115,10 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
     if (condition.isEmpty()) {
       return;
     }
-    Map<String, Object> variables = buildConditionVariables(request);
+    Map<String, Object> variables = HttpServletConditionVariables.build(request);
     if (!conditionEvaluator.evaluate(condition, variables)) {
       throw new FeatureFlagAccessDeniedException(annotation.value());
     }
-  }
-
-  private Map<String, Object> buildConditionVariables(HttpServletRequest request) {
-    Map<String, Object> variables = new HashMap<>();
-    Map<String, String> headers = new HashMap<>();
-    Collections.list(request.getHeaderNames())
-        .forEach(name -> headers.put(name, request.getHeader(name)));
-    variables.put("headers", headers);
-    Map<String, String> params = new HashMap<>();
-    request.getParameterMap().forEach((k, v) -> params.put(k, v.length > 0 ? v[0] : ""));
-    variables.put("params", params);
-    Map<String, String> cookies = new HashMap<>();
-    if (request.getCookies() != null) {
-      Arrays.stream(request.getCookies()).forEach(c -> cookies.put(c.getName(), c.getValue()));
-    }
-    variables.put("cookies", cookies);
-    variables.put("path", request.getRequestURI());
-    variables.put("method", request.getMethod());
-    variables.put("remoteAddress", request.getRemoteAddr());
-    return variables;
   }
 
   private void checkRollout(HttpServletRequest request, FeatureFlag annotation) {

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
@@ -2,9 +2,9 @@ package net.brightroom.featureflag.webmvc.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Map;
 import java.util.Optional;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import net.brightroom.featureflag.core.condition.ConditionVariables;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
@@ -115,7 +115,7 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
     if (condition.isEmpty()) {
       return;
     }
-    Map<String, Object> variables = HttpServletConditionVariables.build(request);
+    ConditionVariables variables = HttpServletConditionVariables.build(request);
     if (!conditionEvaluator.evaluate(condition, variables)) {
       throw new FeatureFlagAccessDeniedException(annotation.value());
     }

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
@@ -46,7 +48,7 @@ class FeatureFlagHandlerFilterFunctionTest {
           rolloutPercentageProvider,
           conditionEvaluator);
 
-  // Filter function with mocked rollout strategy for rollout-specific tests
+  // Filter function with a mocked rollout strategy for rollout-specific tests
   private final RolloutStrategy rolloutStrategy = mock(RolloutStrategy.class);
   private final FeatureFlagHandlerFilterFunction filterFunctionWithRollout =
       new FeatureFlagHandlerFilterFunction(
@@ -233,6 +235,115 @@ class FeatureFlagHandlerFilterFunctionTest {
     assertThat(result).isEqualTo(okResponse);
     verify(rolloutStrategy).isInRollout("my-feature", context, 70);
     verify(next).handle(request);
+  }
+
+  private void stubServletRequestForConditionVariables(HttpServletRequest httpServletRequest) {
+    when(httpServletRequest.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+    when(httpServletRequest.getParameterMap()).thenReturn(Map.of());
+    when(httpServletRequest.getCookies()).thenReturn(null);
+    when(httpServletRequest.getRequestURI()).thenReturn("/functional/condition/header");
+    when(httpServletRequest.getMethod()).thenReturn("GET");
+    when(httpServletRequest.getRemoteAddr()).thenReturn("127.0.0.1");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenConditionPasses() throws Exception {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    stubServletRequestForConditionVariables(httpServletRequest);
+
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.servletRequest()).thenReturn(httpServletRequest);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any())).thenReturn(true);
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(okResponse);
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunction.of("my-feature", "headers['X-Beta'] != null");
+    ServerResponse result = filter.filter(request, next);
+
+    assertThat(result).isEqualTo(okResponse);
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenConditionFails() throws Exception {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    stubServletRequestForConditionVariables(httpServletRequest);
+
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.servletRequest()).thenReturn(httpServletRequest);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any())).thenReturn(false);
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(FeatureFlagAccessDeniedException.class)))
+        .thenReturn(deniedResponse);
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunction.of("my-feature", "headers['X-Beta'] != null");
+    ServerResponse result = filter.filter(request, next);
+
+    assertThat(result).isEqualTo(deniedResponse);
+    verifyNoInteractions(next);
+    verify(resolution).resolve(eq(request), any(FeatureFlagAccessDeniedException.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_skipsConditionCheck_whenConditionIsEmpty() throws Exception {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
+
+    ServerRequest request = mock(ServerRequest.class);
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(okResponse);
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-feature");
+    filter.filter(request, next);
+
+    verifyNoInteractions(conditionEvaluator);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_evaluatesConditionBeforeRollout() throws Exception {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    stubServletRequestForConditionVariables(httpServletRequest);
+
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.servletRequest()).thenReturn(httpServletRequest);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any())).thenReturn(false);
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(FeatureFlagAccessDeniedException.class)))
+        .thenReturn(deniedResponse);
+
+    // rollout = 50, but condition fails first — rollout check must not be reached
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-feature", "headers['X-Beta'] != null", 50);
+    filter.filter(request, next);
+
+    verifyNoInteractions(rolloutPercentageProvider);
+    verifyNoInteractions(contextResolver);
   }
 
   @Test

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import java.util.OptionalInt;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -34,19 +35,27 @@ class FeatureFlagHandlerFilterFunctionTest {
   private final FeatureFlagContextResolver contextResolver = mock(FeatureFlagContextResolver.class);
   private final RolloutPercentageProvider rolloutPercentageProvider =
       mock(RolloutPercentageProvider.class);
+  private final FeatureFlagConditionEvaluator conditionEvaluator =
+      mock(FeatureFlagConditionEvaluator.class);
   private final FeatureFlagHandlerFilterFunction filterFunction =
       new FeatureFlagHandlerFilterFunction(
           provider,
           resolution,
           new DefaultRolloutStrategy(),
           contextResolver,
-          rolloutPercentageProvider);
+          rolloutPercentageProvider,
+          conditionEvaluator);
 
   // Filter function with mocked rollout strategy for rollout-specific tests
   private final RolloutStrategy rolloutStrategy = mock(RolloutStrategy.class);
   private final FeatureFlagHandlerFilterFunction filterFunctionWithRollout =
       new FeatureFlagHandlerFilterFunction(
-          provider, resolution, rolloutStrategy, contextResolver, rolloutPercentageProvider);
+          provider,
+          resolution,
+          rolloutStrategy,
+          contextResolver,
+          rolloutPercentageProvider,
+          conditionEvaluator);
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
@@ -9,9 +9,12 @@ import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
@@ -28,9 +31,15 @@ class FeatureFlagInterceptorTest {
   private final FeatureFlagContextResolver contextResolver = mock(FeatureFlagContextResolver.class);
   private final RolloutPercentageProvider rolloutPercentageProvider =
       mock(RolloutPercentageProvider.class);
+  private final FeatureFlagConditionEvaluator conditionEvaluator =
+      mock(FeatureFlagConditionEvaluator.class);
   private final FeatureFlagInterceptor interceptor =
       new FeatureFlagInterceptor(
-          provider, rolloutStrategy, contextResolver, rolloutPercentageProvider);
+          provider,
+          rolloutStrategy,
+          contextResolver,
+          rolloutPercentageProvider,
+          conditionEvaluator);
 
   private final HttpServletRequest request = mock(HttpServletRequest.class);
   private final HttpServletResponse response = mock(HttpServletResponse.class);
@@ -45,8 +54,13 @@ class FeatureFlagInterceptorTest {
   }
 
   private FeatureFlag featureFlagAnnotation(String value, int rollout) {
+    return featureFlagAnnotation(value, "", rollout);
+  }
+
+  private FeatureFlag featureFlagAnnotation(String value, String condition, int rollout) {
     FeatureFlag annotation = mock(FeatureFlag.class);
     when(annotation.value()).thenReturn(value);
+    when(annotation.condition()).thenReturn(condition);
     when(annotation.rollout()).thenReturn(rollout);
     return annotation;
   }
@@ -222,5 +236,80 @@ class FeatureFlagInterceptorTest {
 
     assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
         .isInstanceOf(FeatureFlagAccessDeniedException.class);
+  }
+
+  // --- condition ---
+
+  private void stubRequestForConditionVariables() {
+    when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getParameterMap()).thenReturn(Map.of());
+    when(request.getCookies()).thenReturn(null);
+    when(request.getRequestURI()).thenReturn("/test");
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+  }
+
+  @Test
+  void preHandle_returnsTrue_whenConditionIsTrue() throws Exception {
+    FeatureFlag annotation = featureFlagAnnotation("my-feature", "headers['X-Beta'] != null", 100);
+    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
+    stubRequestForConditionVariables();
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(true);
+
+    boolean result = interceptor.preHandle(request, response, handlerMethod);
+
+    assertTrue(result);
+  }
+
+  @Test
+  void preHandle_throwsFeatureFlagAccessDeniedException_whenConditionIsFalse() {
+    FeatureFlag annotation = featureFlagAnnotation("my-feature", "headers['X-Beta'] != null", 100);
+    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    stubRequestForConditionVariables();
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+        .isInstanceOf(FeatureFlagAccessDeniedException.class);
+  }
+
+  @Test
+  void preHandle_skipsConditionCheck_whenConditionIsEmpty() throws Exception {
+    FeatureFlag annotation = featureFlagAnnotation("my-feature", "", 100);
+    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
+
+    boolean result = interceptor.preHandle(request, response, handlerMethod);
+
+    assertTrue(result);
+    verifyNoInteractions(conditionEvaluator);
+  }
+
+  @Test
+  void preHandle_evaluatesConditionBeforeRollout() throws Exception {
+    FeatureFlag annotation = featureFlagAnnotation("my-feature", "headers['X-Beta'] != null", 50);
+    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    stubRequestForConditionVariables();
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(false);
+
+    // Condition fails, so rollout should not be checked
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+        .isInstanceOf(FeatureFlagAccessDeniedException.class);
+    verifyNoInteractions(rolloutStrategy);
   }
 }


### PR DESCRIPTION
## Summary

- Add `condition` attribute to `@FeatureFlag` annotation for SpEL-based request context evaluation (headers, params, cookies, path, method, remoteAddress)
- Implement `FeatureFlagConditionEvaluator` SPI with `SpelFeatureFlagConditionEvaluator` default using `SimpleEvaluationContext` (blocks type references, constructors, bean references)
- Add `feature-flags.condition.fail-on-error` property (default: `true` = fail-closed)
- Integrate into WebMVC (interceptor + filter) and WebFlux (aspect + filter) with evaluation order: enabled → condition → rollout

### Usage
```java
@FeatureFlag(value = "beta-feature", condition = "headers['X-Beta-User'] != null")
@FeatureFlag(value = "us-only", condition = "headers['X-Region'] == 'us-east-1'")
@FeatureFlag(value = "ab-test", condition = "params['variant'] == 'B'")
@FeatureFlag(value = "new-ui", condition = "headers['X-Beta'] != null", rollout = 50)
```

## Test plan

- [x] `SpelFeatureFlagConditionEvaluator` unit tests (header/param/cookie/path/method checks, compound conditions, fail-on-error modes, security: type reference and constructor injection blocked, expression caching)
- [x] `FeatureFlagInterceptor` unit tests (condition true/false, empty condition skip, condition before rollout ordering)
- [x] `FeatureFlagAspect` existing unit tests pass with new constructor
- [x] `FeatureFlagHandlerFilterFunction` (both webmvc/webflux) existing unit tests pass with new constructor
- [x] WebMVC integration tests: header-based and param-based condition endpoints, functional endpoint condition routing
- [x] WebFlux integration tests: header-based and param-based condition endpoints, functional endpoint condition routing
- [x] All existing tests continue to pass (`./gradlew check` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)