### PR TITLE
Close #124: feat: add schedule-based feature flag control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,10 @@ This is a multi-module Gradle project (Java 25, Spring Boot 4.x) that provides f
 1. `FeatureFlagMvcInterceptorRegistrationAutoConfiguration` registers `FeatureFlagInterceptor` for all paths (`/**`).
 2. `FeatureFlagInterceptor.preHandle()` checks `@FeatureFlag` on the method first, then on the class. Method-level annotation takes priority.
 3. If the feature is disabled, `FeatureFlagAccessDeniedException` is thrown.
-4. If `condition` is non-empty, the SpEL expression is evaluated against request context variables (`headers`, `params`, `cookies`, `path`, `method`, `remoteAddress`). If the condition is not satisfied, `FeatureFlagAccessDeniedException` is thrown.
-5. If `rollout < 100`, the rollout percentage check is performed.
-6. `FeatureFlagExceptionHandler` (`@ControllerAdvice`, `@Order(Ordered.LOWEST_PRECEDENCE)`) catches the exception and delegates to `AccessDeniedInterceptResolution.resolution()` to write the response.
+4. If a schedule is configured for the feature (via `ScheduleProvider`) and it is currently inactive, `FeatureFlagAccessDeniedException` is thrown.
+5. If `condition` is non-empty, the SpEL expression is evaluated against request context variables (`headers`, `params`, `cookies`, `path`, `method`, `remoteAddress`). If the condition is not satisfied, `FeatureFlagAccessDeniedException` is thrown.
+6. If `rollout < 100`, the rollout percentage check is performed.
+7. `FeatureFlagExceptionHandler` (`@ControllerAdvice`, `@Order(Ordered.LOWEST_PRECEDENCE)`) catches the exception and delegates to `AccessDeniedInterceptResolution.resolution()` to write the response.
 
 ### Extension Points
 
@@ -57,6 +58,7 @@ This is a multi-module Gradle project (Java 25, Spring Boot 4.x) that provides f
 - **Custom denied response**: Define a `@ControllerAdvice` that handles `FeatureFlagAccessDeniedException`. It takes priority over the library's default handler.
 - **Conditional access**: Use `@FeatureFlag(value = "name", condition = "headers['X-Beta'] != null")` to enable a feature only when a SpEL condition evaluated against request context is satisfied. Implement `FeatureFlagConditionEvaluator` (webmvc) or `ReactiveFeatureFlagConditionEvaluator` (webflux) to replace the default SpEL evaluator. The `@FeatureFlag` annotation also exposes a `condition` attribute; the `ConditionVariablesBuilder` in core centralizes the available variable key names (`headers`, `params`, `cookies`, `path`, `method`, `remoteAddress`). Configure fail-on-error behavior with `feature-flags.condition.fail-on-error`.
 - **Gradual rollout**: Use `@FeatureFlag(value = "name", rollout = 50)` to enable a feature for a percentage of requests. Implement `FeatureFlagContextResolver` (webmvc) or `ReactiveFeatureFlagContextResolver` (webflux) for sticky rollout. Implement `RolloutStrategy` (webmvc) or `ReactiveRolloutStrategy` (webflux) to customize bucketing.
+- **Schedule-based activation**: Configure `feature-flags.features.<name>.schedule.start/end/timezone` in properties to activate a feature only during a time window. The check uses server-side `Clock.instant()` evaluated against the configured schedule. Implement `ScheduleProvider` (webmvc/actuator) or `ReactiveScheduleProvider` (webflux/actuator) and register as a `@Bean` to load schedules from a custom source (database, remote config, etc.). The default `InMemoryScheduleProvider` / `InMemoryReactiveScheduleProvider` reads from the property binding. The `Schedule` record (`core/provider/`) is the SPI value type returned by these providers.
 
 ### Auto-configuration Registration
 

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.actuator.autoconfigure;
 
+import java.time.Clock;
 import java.util.List;
 import net.brightroom.featureflag.actuator.endpoint.FeatureFlagEndpoint;
 import net.brightroom.featureflag.actuator.endpoint.ReactiveFeatureFlagEndpoint;
@@ -11,6 +12,8 @@ import net.brightroom.featureflag.actuator.health.ReactiveHealthDetailsContribut
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
+import net.brightroom.featureflag.core.provider.InMemoryReactiveScheduleProvider;
+import net.brightroom.featureflag.core.provider.InMemoryScheduleProvider;
 import net.brightroom.featureflag.core.provider.MutableFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveFeatureFlagProvider;
@@ -21,7 +24,9 @@ import net.brightroom.featureflag.core.provider.MutableReactiveRolloutPercentage
 import net.brightroom.featureflag.core.provider.MutableRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -96,6 +101,29 @@ public class FeatureFlagActuatorAutoConfiguration {
     }
 
     /**
+     * Registers an {@link InMemoryScheduleProvider} bean when no other {@link ScheduleProvider}
+     * bean is already present.
+     *
+     * @return the in-memory schedule provider initialized from {@link FeatureFlagProperties}
+     */
+    @Bean
+    @ConditionalOnMissingBean(ScheduleProvider.class)
+    InMemoryScheduleProvider scheduleProvider() {
+      return new InMemoryScheduleProvider(featureFlagProperties.schedules());
+    }
+
+    /**
+     * Registers a {@link Clock} bean when no other {@link Clock} bean is already present.
+     *
+     * @return the system default clock
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    Clock featureFlagClock() {
+      return Clock.systemDefaultZone();
+    }
+
+    /**
      * Registers the {@link FeatureFlagHealthIndicator} bean when the {@code featureFlag} health
      * indicator is enabled.
      *
@@ -117,7 +145,9 @@ public class FeatureFlagActuatorAutoConfiguration {
      *
      * @param provider the mutable feature flag provider
      * @param rolloutProvider the mutable rollout percentage provider
+     * @param scheduleProvider the schedule provider
      * @param eventPublisher the publisher used to broadcast flag change events
+     * @param clock the clock used for schedule evaluation
      * @return the feature flag actuator endpoint
      */
     @Bean
@@ -125,9 +155,16 @@ public class FeatureFlagActuatorAutoConfiguration {
     FeatureFlagEndpoint featureFlagEndpoint(
         MutableFeatureFlagProvider provider,
         MutableRolloutPercentageProvider rolloutProvider,
-        ApplicationEventPublisher eventPublisher) {
+        ScheduleProvider scheduleProvider,
+        ApplicationEventPublisher eventPublisher,
+        Clock clock) {
       return new FeatureFlagEndpoint(
-          provider, rolloutProvider, featureFlagProperties.defaultEnabled(), eventPublisher);
+          provider,
+          rolloutProvider,
+          scheduleProvider,
+          featureFlagProperties.defaultEnabled(),
+          eventPublisher,
+          clock);
     }
 
     ServletConfiguration(
@@ -174,6 +211,30 @@ public class FeatureFlagActuatorAutoConfiguration {
     }
 
     /**
+     * Registers an {@link InMemoryReactiveScheduleProvider} bean when no other {@link
+     * ReactiveScheduleProvider} bean is already present.
+     *
+     * @return the in-memory reactive schedule provider initialized from {@link
+     *     FeatureFlagProperties}
+     */
+    @Bean
+    @ConditionalOnMissingBean(ReactiveScheduleProvider.class)
+    InMemoryReactiveScheduleProvider reactiveScheduleProvider() {
+      return new InMemoryReactiveScheduleProvider(featureFlagProperties.schedules());
+    }
+
+    /**
+     * Registers a {@link Clock} bean when no other {@link Clock} bean is already present.
+     *
+     * @return the system default clock
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    Clock featureFlagClock() {
+      return Clock.systemDefaultZone();
+    }
+
+    /**
      * Registers the {@link ReactiveFeatureFlagHealthIndicator} bean when the {@code featureFlag}
      * health indicator is enabled.
      *
@@ -195,7 +256,9 @@ public class FeatureFlagActuatorAutoConfiguration {
      *
      * @param provider the mutable reactive feature flag provider
      * @param rolloutProvider the mutable reactive rollout percentage provider
+     * @param reactiveScheduleProvider the reactive schedule provider
      * @param eventPublisher the publisher used to broadcast flag change events
+     * @param clock the clock used for schedule evaluation
      * @return the reactive feature flag actuator endpoint
      */
     @Bean
@@ -203,9 +266,16 @@ public class FeatureFlagActuatorAutoConfiguration {
     ReactiveFeatureFlagEndpoint reactiveFeatureFlagEndpoint(
         MutableReactiveFeatureFlagProvider provider,
         MutableReactiveRolloutPercentageProvider rolloutProvider,
-        ApplicationEventPublisher eventPublisher) {
+        ReactiveScheduleProvider reactiveScheduleProvider,
+        ApplicationEventPublisher eventPublisher,
+        Clock clock) {
       return new ReactiveFeatureFlagEndpoint(
-          provider, rolloutProvider, featureFlagProperties.defaultEnabled(), eventPublisher);
+          provider,
+          rolloutProvider,
+          reactiveScheduleProvider,
+          featureFlagProperties.defaultEnabled(),
+          eventPublisher,
+          clock);
     }
 
     ReactiveConfiguration(

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
@@ -1,10 +1,12 @@
 package net.brightroom.featureflag.actuator.endpoint;
 
+import java.time.Clock;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
 import net.brightroom.featureflag.core.provider.MutableFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.actuate.endpoint.Access;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
@@ -32,8 +34,10 @@ public class FeatureFlagEndpoint {
 
   private final MutableFeatureFlagProvider provider;
   private final MutableRolloutPercentageProvider rolloutProvider;
+  private final ScheduleProvider scheduleProvider;
   private final boolean defaultEnabled;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   /**
    * Returns the current state of all feature flags.
@@ -61,7 +65,8 @@ public class FeatureFlagEndpoint {
     return new FeatureFlagEndpointResponse(
         featureName,
         provider.isFeatureEnabled(featureName),
-        rolloutProvider.getRolloutPercentage(featureName).orElse(100));
+        rolloutProvider.getRolloutPercentage(featureName).orElse(100),
+        buildScheduleResponse(featureName));
   }
 
   /**
@@ -125,9 +130,26 @@ public class FeatureFlagEndpoint {
             .map(
                 e ->
                     new FeatureFlagEndpointResponse(
-                        e.getKey(), e.getValue(), rolloutPercentages.getOrDefault(e.getKey(), 100)))
+                        e.getKey(),
+                        e.getValue(),
+                        rolloutPercentages.getOrDefault(e.getKey(), 100),
+                        buildScheduleResponse(e.getKey())))
             .toList();
     return new FeatureFlagsEndpointResponse(featureList, defaultEnabled);
+  }
+
+  @Nullable
+  private ScheduleEndpointResponse buildScheduleResponse(String featureName) {
+    return scheduleProvider
+        .getSchedule(featureName)
+        .map(
+            schedule ->
+                new ScheduleEndpointResponse(
+                    schedule.start(),
+                    schedule.end(),
+                    schedule.timezone(),
+                    schedule.isActive(clock.instant())))
+        .orElse(null);
   }
 
   /**
@@ -135,17 +157,23 @@ public class FeatureFlagEndpoint {
    *
    * @param provider the mutable feature flag provider
    * @param rolloutProvider the mutable rollout percentage provider
+   * @param scheduleProvider the schedule provider used to look up schedules per feature
    * @param defaultEnabled the default-enabled value to include in responses
    * @param eventPublisher the publisher used to broadcast flag change events
+   * @param clock the clock used to determine schedule active status in responses
    */
   public FeatureFlagEndpoint(
       MutableFeatureFlagProvider provider,
       MutableRolloutPercentageProvider rolloutProvider,
+      ScheduleProvider scheduleProvider,
       boolean defaultEnabled,
-      ApplicationEventPublisher eventPublisher) {
+      ApplicationEventPublisher eventPublisher,
+      Clock clock) {
     this.provider = provider;
     this.rolloutProvider = rolloutProvider;
+    this.scheduleProvider = scheduleProvider;
     this.defaultEnabled = defaultEnabled;
     this.eventPublisher = eventPublisher;
+    this.clock = clock;
   }
 }

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointResponse.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointResponse.java
@@ -1,5 +1,7 @@
 package net.brightroom.featureflag.actuator.endpoint;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Response body for the {@code /actuator/feature-flags/{featureName}} endpoint.
  *
@@ -8,5 +10,20 @@ package net.brightroom.featureflag.actuator.endpoint;
  * @param featureName the name of the feature flag
  * @param enabled the current enabled state of the feature flag
  * @param rollout the current rollout percentage (0–100) of the feature flag
+ * @param schedule the schedule configuration for this flag, or {@code null} if no schedule is
+ *     configured
  */
-public record FeatureFlagEndpointResponse(String featureName, boolean enabled, int rollout) {}
+public record FeatureFlagEndpointResponse(
+    String featureName, boolean enabled, int rollout, @Nullable ScheduleEndpointResponse schedule) {
+
+  /**
+   * Creates a response without schedule information.
+   *
+   * @param featureName the name of the feature flag
+   * @param enabled the current enabled state of the feature flag
+   * @param rollout the current rollout percentage (0–100) of the feature flag
+   */
+  public FeatureFlagEndpointResponse(String featureName, boolean enabled, int rollout) {
+    this(featureName, enabled, rollout, null);
+  }
+}

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
@@ -5,10 +5,10 @@ import java.util.List;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
-import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
+import net.brightroom.featureflag.core.provider.Schedule;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.actuate.endpoint.Access;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
@@ -147,7 +147,7 @@ public class ReactiveFeatureFlagEndpoint {
 
   @Nullable
   private ScheduleEndpointResponse buildScheduleResponse(String featureName) {
-    ScheduleConfiguration schedule =
+    Schedule schedule =
         reactiveScheduleProvider.getSchedule(featureName).blockOptional().orElse(null);
     if (schedule == null) {
       return null;

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
@@ -1,11 +1,14 @@
 package net.brightroom.featureflag.actuator.endpoint;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
+import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.actuate.endpoint.Access;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
@@ -34,8 +37,10 @@ public class ReactiveFeatureFlagEndpoint {
 
   private final MutableReactiveFeatureFlagProvider provider;
   private final MutableReactiveRolloutPercentageProvider rolloutProvider;
+  private final ReactiveScheduleProvider reactiveScheduleProvider;
   private final boolean defaultEnabled;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
 
   /**
    * Returns the current state of all feature flags.
@@ -62,7 +67,8 @@ public class ReactiveFeatureFlagEndpoint {
     }
     var enabled = provider.isFeatureEnabled(featureName).block();
     var rollout = rolloutProvider.getRolloutPercentage(featureName).blockOptional().orElse(100);
-    return new FeatureFlagEndpointResponse(featureName, Boolean.TRUE.equals(enabled), rollout);
+    return new FeatureFlagEndpointResponse(
+        featureName, Boolean.TRUE.equals(enabled), rollout, buildScheduleResponse(featureName));
   }
 
   /**
@@ -131,9 +137,23 @@ public class ReactiveFeatureFlagEndpoint {
             .map(
                 e ->
                     new FeatureFlagEndpointResponse(
-                        e.getKey(), e.getValue(), rolloutPercentages.getOrDefault(e.getKey(), 100)))
+                        e.getKey(),
+                        e.getValue(),
+                        rolloutPercentages.getOrDefault(e.getKey(), 100),
+                        buildScheduleResponse(e.getKey())))
             .toList();
     return new FeatureFlagsEndpointResponse(featureList, defaultEnabled);
+  }
+
+  @Nullable
+  private ScheduleEndpointResponse buildScheduleResponse(String featureName) {
+    ScheduleConfiguration schedule =
+        reactiveScheduleProvider.getSchedule(featureName).blockOptional().orElse(null);
+    if (schedule == null) {
+      return null;
+    }
+    return new ScheduleEndpointResponse(
+        schedule.start(), schedule.end(), schedule.timezone(), schedule.isActive(clock.instant()));
   }
 
   /**
@@ -141,17 +161,24 @@ public class ReactiveFeatureFlagEndpoint {
    *
    * @param provider the mutable reactive feature flag provider
    * @param rolloutProvider the mutable reactive rollout percentage provider
+   * @param reactiveScheduleProvider the reactive schedule provider used to look up schedules per
+   *     feature
    * @param defaultEnabled the default-enabled value to include in responses
    * @param eventPublisher the publisher used to broadcast flag change events
+   * @param clock the clock used to determine schedule active status in responses
    */
   public ReactiveFeatureFlagEndpoint(
       MutableReactiveFeatureFlagProvider provider,
       MutableReactiveRolloutPercentageProvider rolloutProvider,
+      ReactiveScheduleProvider reactiveScheduleProvider,
       boolean defaultEnabled,
-      ApplicationEventPublisher eventPublisher) {
+      ApplicationEventPublisher eventPublisher,
+      Clock clock) {
     this.provider = provider;
     this.rolloutProvider = rolloutProvider;
+    this.reactiveScheduleProvider = reactiveScheduleProvider;
     this.defaultEnabled = defaultEnabled;
     this.eventPublisher = eventPublisher;
+    this.clock = clock;
   }
 }

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ScheduleEndpointResponse.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ScheduleEndpointResponse.java
@@ -1,0 +1,22 @@
+package net.brightroom.featureflag.actuator.endpoint;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Response fragment representing the schedule configuration of a single feature flag.
+ *
+ * <p>Included in {@link FeatureFlagEndpointResponse} when a schedule is configured for the feature.
+ *
+ * @param start the schedule start time, or {@code null} if no start restriction is configured
+ * @param end the schedule end time, or {@code null} if no end restriction is configured
+ * @param timezone the timezone used to evaluate start/end times, or {@code null} if the system
+ *     default timezone is used
+ * @param active whether the schedule is currently active at the time the response was generated
+ */
+public record ScheduleEndpointResponse(
+    @Nullable LocalDateTime start,
+    @Nullable LocalDateTime end,
+    @Nullable ZoneId timezone,
+    boolean active) {}

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
@@ -12,12 +12,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
 import net.brightroom.featureflag.core.provider.InMemoryScheduleProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.Schedule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -46,6 +50,19 @@ class FeatureFlagEndpointTest {
       boolean defaultEnabled) {
     return new FeatureFlagEndpoint(
         provider, rolloutProvider, emptyScheduleProvider(), defaultEnabled, eventPublisher, clock);
+  }
+
+  private FeatureFlagEndpoint endpointWithSchedule(
+      MutableInMemoryFeatureFlagProvider provider,
+      Map<String, Schedule> schedules,
+      boolean defaultEnabled) {
+    return new FeatureFlagEndpoint(
+        provider,
+        emptyRolloutProvider(),
+        new InMemoryScheduleProvider(schedules),
+        defaultEnabled,
+        eventPublisher,
+        clock);
   }
 
   @Test
@@ -404,5 +421,85 @@ class FeatureFlagEndpointTest {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature("   "))
         .withMessageContaining("featureName must not be null or blank");
+  }
+
+  // --- schedule response (M-2) ---
+
+  @Test
+  void feature_returnsSchedule_whenScheduleIsConfigured() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
+    // active schedule: start in the past, no end
+    var schedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    var endpoint = endpointWithSchedule(provider, Map.of("feature-a", schedule), false);
+
+    var response = endpoint.feature("feature-a");
+
+    assertThat(response.schedule()).isNotNull();
+    assertThat(response.schedule().start()).isEqualTo(LocalDateTime.of(2020, 1, 1, 0, 0));
+    assertThat(response.schedule().end()).isNull();
+    assertTrue(response.schedule().active());
+  }
+
+  @Test
+  void feature_returnsNullSchedule_whenNoScheduleIsConfigured() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
+
+    var response = endpoint.feature("feature-a");
+
+    assertNull(response.schedule());
+  }
+
+  @Test
+  void feature_returnsInactiveSchedule_whenScheduleWindowHasPassed() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
+    // Inactive: end in the past
+    var schedule =
+        new Schedule(
+            null,
+            LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")).plusDays(1),
+            ZoneId.of("UTC"));
+    // Use a fixed clock far in the future so the schedule is inactive
+    var fixedClock = Clock.fixed(Instant.now().plusSeconds(86400 * 365 * 100), ZoneId.of("UTC"));
+    var endpointWithFixedClock =
+        new FeatureFlagEndpoint(
+            provider,
+            emptyRolloutProvider(),
+            new InMemoryScheduleProvider(Map.of("feature-a", schedule)),
+            false,
+            eventPublisher,
+            fixedClock);
+
+    var response = endpointWithFixedClock.feature("feature-a");
+
+    assertThat(response.schedule()).isNotNull();
+    assertFalse(response.schedule().active());
+  }
+
+  @Test
+  void features_includesSchedule_whenScheduleIsConfigured() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
+    var schedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    var endpoint = endpointWithSchedule(provider, Map.of("feature-a", schedule), false);
+
+    var response = endpoint.features();
+
+    assertThat(response.features())
+        .filteredOn(f -> f.featureName().equals("feature-a"))
+        .extracting(FeatureFlagEndpointResponse::schedule)
+        .doesNotContainNull();
+  }
+
+  @Test
+  void features_hasNullSchedule_whenNoScheduleConfigured() {
+    var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
+
+    var response = endpoint.features();
+
+    assertThat(response.features())
+        .filteredOn(f -> f.featureName().equals("feature-a"))
+        .extracting(FeatureFlagEndpointResponse::schedule)
+        .containsOnlyNulls();
   }
 }

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
@@ -11,9 +11,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.time.Clock;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
+import net.brightroom.featureflag.core.provider.InMemoryScheduleProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryRolloutPercentageProvider;
 import org.junit.jupiter.api.Test;
@@ -28,8 +30,22 @@ class FeatureFlagEndpointTest {
 
   @Mock ApplicationEventPublisher eventPublisher;
 
+  private final Clock clock = Clock.systemDefaultZone();
+
   private MutableInMemoryRolloutPercentageProvider emptyRolloutProvider() {
     return new MutableInMemoryRolloutPercentageProvider(Map.of());
+  }
+
+  private InMemoryScheduleProvider emptyScheduleProvider() {
+    return new InMemoryScheduleProvider(Map.of());
+  }
+
+  private FeatureFlagEndpoint endpoint(
+      MutableInMemoryFeatureFlagProvider provider,
+      MutableInMemoryRolloutPercentageProvider rolloutProvider,
+      boolean defaultEnabled) {
+    return new FeatureFlagEndpoint(
+        provider, rolloutProvider, emptyScheduleProvider(), defaultEnabled, eventPublisher, clock);
   }
 
   @Test
@@ -37,7 +53,7 @@ class FeatureFlagEndpointTest {
     var provider =
         new MutableInMemoryFeatureFlagProvider(
             Map.of("feature-a", true, "feature-b", false), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.features();
 
@@ -50,7 +66,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_updatesExistingFlagAndReturnsUpdatedState() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.updateFeature("feature-a", false, null);
 
@@ -63,7 +79,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_publishesFeatureFlagChangedEvent() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.updateFeature("feature-a", false, null);
 
@@ -76,7 +92,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_addsNewFlagNotPreviouslyDefined() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.updateFeature("new-flag", true, null);
 
@@ -89,7 +105,7 @@ class FeatureFlagEndpointTest {
   @Test
   void features_returnsDefaultEnabled_true_whenConfigured() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), true);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), true, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), true);
 
     var response = endpoint.features();
 
@@ -100,7 +116,7 @@ class FeatureFlagEndpointTest {
   void updateFeature_responseReflectsAllFlagsIncludingUnchanged() {
     var provider =
         new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true, "feature-b", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.updateFeature("feature-a", false, null);
 
@@ -113,7 +129,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsNull() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature(null, true, null))
@@ -123,7 +139,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsEmpty() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("", true, null))
@@ -133,7 +149,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsBlank() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("   ", true, null))
@@ -143,7 +159,7 @@ class FeatureFlagEndpointTest {
   @Test
   void feature_returnsEnabledFlag() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("feature-a");
 
@@ -154,7 +170,7 @@ class FeatureFlagEndpointTest {
   @Test
   void feature_returnsDisabledFlag() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", false), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("feature-a");
 
@@ -165,7 +181,7 @@ class FeatureFlagEndpointTest {
   @Test
   void feature_returnsDefaultEnabled_whenFlagIsUndefined() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("undefined-flag");
 
@@ -176,7 +192,7 @@ class FeatureFlagEndpointTest {
   @Test
   void feature_returnsDefaultEnabled_true_whenFlagIsUndefined_andDefaultEnabledIsTrue() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), true);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), true, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), true);
 
     var response = endpoint.feature("undefined-flag");
 
@@ -188,7 +204,7 @@ class FeatureFlagEndpointTest {
   void features_returnsRolloutPercentagesFromProvider() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider = new MutableInMemoryRolloutPercentageProvider(Map.of("feature-a", 50));
-    var endpoint = new FeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     var response = endpoint.features();
 
@@ -201,7 +217,7 @@ class FeatureFlagEndpointTest {
   @Test
   void features_returnsDefaultRollout100_whenNotConfigured() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.features();
 
@@ -215,7 +231,7 @@ class FeatureFlagEndpointTest {
   void feature_returnsRolloutPercentageFromProvider() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider = new MutableInMemoryRolloutPercentageProvider(Map.of("feature-a", 75));
-    var endpoint = new FeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     var response = endpoint.feature("feature-a");
 
@@ -225,7 +241,7 @@ class FeatureFlagEndpointTest {
   @Test
   void feature_returnsDefaultRollout100_whenNotConfigured() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("feature-a");
 
@@ -236,7 +252,7 @@ class FeatureFlagEndpointTest {
   void updateFeature_updatesRolloutPercentage() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider = new MutableInMemoryRolloutPercentageProvider(Map.of());
-    var endpoint = new FeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     var response = endpoint.updateFeature("feature-a", true, 50);
 
@@ -249,7 +265,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_publishesEventWithRolloutPercentage() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.updateFeature("feature-a", true, 60);
 
@@ -262,7 +278,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_publishesEventWithNullRollout_whenRolloutNotSpecified() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.updateFeature("feature-a", true, null);
 
@@ -274,7 +290,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenRolloutIsNegative() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("feature-a", true, -1))
@@ -284,7 +300,7 @@ class FeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenRolloutExceeds100() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("feature-a", true, 101))
@@ -295,7 +311,7 @@ class FeatureFlagEndpointTest {
   void updateFeature_acceptsBoundaryRolloutValues() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider = new MutableInMemoryRolloutPercentageProvider(Map.of());
-    var endpoint = new FeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 0));
     assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 100));
@@ -304,7 +320,7 @@ class FeatureFlagEndpointTest {
   @Test
   void deleteFeature_removesFlagFromProvider() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -315,7 +331,7 @@ class FeatureFlagEndpointTest {
   @Test
   void deleteFeature_publishesFeatureFlagRemovedEvent() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -328,7 +344,7 @@ class FeatureFlagEndpointTest {
   void deleteFeature_removesRolloutPercentage() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider = new MutableInMemoryRolloutPercentageProvider(Map.of("feature-a", 50));
-    var endpoint = new FeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -340,7 +356,7 @@ class FeatureFlagEndpointTest {
     var provider =
         new MutableInMemoryFeatureFlagProvider(
             Map.of("feature-a", true, "feature-b", false), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -353,7 +369,7 @@ class FeatureFlagEndpointTest {
   @Test
   void deleteFeature_isIdempotent_whenFlagDoesNotExist() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatNoException().isThrownBy(() -> endpoint.deleteFeature("nonexistent"));
     // 非存在フラグの削除ではイベントが発行されない
@@ -363,7 +379,7 @@ class FeatureFlagEndpointTest {
   @Test
   void deleteFeature_throwsIllegalArgumentException_whenFeatureNameIsNull() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature(null))
@@ -373,7 +389,7 @@ class FeatureFlagEndpointTest {
   @Test
   void deleteFeature_throwsIllegalArgumentException_whenFeatureNameIsEmpty() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature(""))
@@ -383,7 +399,7 @@ class FeatureFlagEndpointTest {
   @Test
   void deleteFeature_throwsIllegalArgumentException_whenFeatureNameIsBlank() {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
-    var endpoint = new FeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature("   "))

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpointTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpointTest.java
@@ -13,9 +13,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
+import net.brightroom.featureflag.core.provider.InMemoryReactiveScheduleProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
@@ -32,8 +34,22 @@ class ReactiveFeatureFlagEndpointTest {
 
   @Mock ApplicationEventPublisher eventPublisher;
 
+  private final Clock clock = Clock.systemDefaultZone();
+
   private MutableInMemoryReactiveRolloutPercentageProvider emptyRolloutProvider() {
     return new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+  }
+
+  private InMemoryReactiveScheduleProvider emptyScheduleProvider() {
+    return new InMemoryReactiveScheduleProvider(Map.of());
+  }
+
+  private ReactiveFeatureFlagEndpoint endpoint(
+      MutableInMemoryReactiveFeatureFlagProvider provider,
+      MutableInMemoryReactiveRolloutPercentageProvider rolloutProvider,
+      boolean defaultEnabled) {
+    return new ReactiveFeatureFlagEndpoint(
+        provider, rolloutProvider, emptyScheduleProvider(), defaultEnabled, eventPublisher, clock);
   }
 
   @Test
@@ -41,8 +57,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider =
         new MutableInMemoryReactiveFeatureFlagProvider(
             Map.of("feature-a", true, "feature-b", false), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.features();
 
@@ -55,8 +70,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_updatesExistingFlagAndReturnsUpdatedState() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.updateFeature("feature-a", false, null);
 
@@ -69,8 +83,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_publishesFeatureFlagChangedEvent() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.updateFeature("feature-a", false, null);
 
@@ -83,8 +96,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_addsNewFlagNotPreviouslyDefined() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.updateFeature("new-flag", true, null);
 
@@ -97,8 +109,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void features_returnsDefaultEnabled_true_whenConfigured() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), true);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), true, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), true);
 
     var response = endpoint.features();
 
@@ -110,8 +121,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider =
         new MutableInMemoryReactiveFeatureFlagProvider(
             Map.of("feature-a", true, "feature-b", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.updateFeature("feature-a", false, null);
 
@@ -124,8 +134,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsNull() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature(null, true, null))
@@ -135,8 +144,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsEmpty() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("", true, null))
@@ -146,8 +154,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenFeatureNameIsBlank() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("   ", true, null))
@@ -157,8 +164,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void feature_returnsEnabledFlag() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("feature-a");
 
@@ -170,8 +176,7 @@ class ReactiveFeatureFlagEndpointTest {
   void feature_returnsDisabledFlag() {
     var provider =
         new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", false), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("feature-a");
 
@@ -182,8 +187,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void feature_returnsDefaultEnabled_whenFlagIsUndefined() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("undefined-flag");
 
@@ -194,8 +198,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void feature_returnsDefaultEnabled_true_whenFlagIsUndefined_andDefaultEnabledIsTrue() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), true);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), true, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), true);
 
     var response = endpoint.feature("undefined-flag");
 
@@ -208,7 +211,13 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = mock(MutableReactiveFeatureFlagProvider.class);
     when(provider.getFeatures()).thenReturn(Mono.empty());
     var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+        new ReactiveFeatureFlagEndpoint(
+            provider,
+            emptyRolloutProvider(),
+            emptyScheduleProvider(),
+            false,
+            eventPublisher,
+            clock);
 
     var response = endpoint.features();
 
@@ -221,8 +230,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider =
         new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     var response = endpoint.features();
 
@@ -235,8 +243,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void features_returnsDefaultRollout100_whenNotConfigured() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.features();
 
@@ -251,8 +258,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider =
         new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 75));
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     var response = endpoint.feature("feature-a");
 
@@ -262,8 +268,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void feature_returnsDefaultRollout100_whenNotConfigured() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     var response = endpoint.feature("feature-a");
 
@@ -274,8 +279,7 @@ class ReactiveFeatureFlagEndpointTest {
   void updateFeature_updatesRolloutPercentage() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     var response = endpoint.updateFeature("feature-a", true, 50);
 
@@ -288,8 +292,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_publishesEventWithRolloutPercentage() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.updateFeature("feature-a", true, 60);
 
@@ -302,8 +305,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_publishesEventWithNullRollout_whenRolloutNotSpecified() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.updateFeature("feature-a", true, null);
 
@@ -315,8 +317,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenRolloutIsNegative() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("feature-a", true, -1))
@@ -326,8 +327,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void updateFeature_throwsIllegalArgumentException_whenRolloutExceeds100() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.updateFeature("feature-a", true, 101))
@@ -338,8 +338,7 @@ class ReactiveFeatureFlagEndpointTest {
   void updateFeature_acceptsBoundaryRolloutValues() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 0));
     assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 100));
@@ -348,8 +347,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void deleteFeature_removesFlagFromProvider() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -360,8 +358,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void deleteFeature_publishesFeatureFlagRemovedEvent() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -375,8 +372,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var rolloutProvider =
         new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("feature-a", 50));
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, rolloutProvider, false, eventPublisher);
+    var endpoint = endpoint(provider, rolloutProvider, false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -388,8 +384,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider =
         new MutableInMemoryReactiveFeatureFlagProvider(
             Map.of("feature-a", true, "feature-b", false), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     endpoint.deleteFeature("feature-a");
 
@@ -402,8 +397,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void deleteFeature_isIdempotent_whenFlagDoesNotExist() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatNoException().isThrownBy(() -> endpoint.deleteFeature("nonexistent"));
     // 非存在フラグの削除ではイベントが発行されない
@@ -413,8 +407,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void deleteFeature_throwsIllegalArgumentException_whenFeatureNameIsNull() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature(null))
@@ -424,8 +417,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void deleteFeature_throwsIllegalArgumentException_whenFeatureNameIsEmpty() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature(""))
@@ -435,8 +427,7 @@ class ReactiveFeatureFlagEndpointTest {
   @Test
   void deleteFeature_throwsIllegalArgumentException_whenFeatureNameIsBlank() {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
-    var endpoint =
-        new ReactiveFeatureFlagEndpoint(provider, emptyRolloutProvider(), false, eventPublisher);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature("   "))

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpointTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpointTest.java
@@ -14,6 +14,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
@@ -21,6 +24,7 @@ import net.brightroom.featureflag.core.provider.InMemoryReactiveScheduleProvider
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
+import net.brightroom.featureflag.core.provider.Schedule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -50,6 +54,19 @@ class ReactiveFeatureFlagEndpointTest {
       boolean defaultEnabled) {
     return new ReactiveFeatureFlagEndpoint(
         provider, rolloutProvider, emptyScheduleProvider(), defaultEnabled, eventPublisher, clock);
+  }
+
+  private ReactiveFeatureFlagEndpoint endpointWithSchedule(
+      MutableInMemoryReactiveFeatureFlagProvider provider,
+      Map<String, Schedule> schedules,
+      boolean defaultEnabled) {
+    return new ReactiveFeatureFlagEndpoint(
+        provider,
+        emptyRolloutProvider(),
+        new InMemoryReactiveScheduleProvider(schedules),
+        defaultEnabled,
+        eventPublisher,
+        clock);
   }
 
   @Test
@@ -432,5 +449,84 @@ class ReactiveFeatureFlagEndpointTest {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> endpoint.deleteFeature("   "))
         .withMessageContaining("featureName must not be null or blank");
+  }
+
+  // --- schedule response (M-2) ---
+
+  @Test
+  void feature_returnsSchedule_whenScheduleIsConfigured() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
+    // active schedule: start in the past, no end
+    var schedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    var endpoint = endpointWithSchedule(provider, Map.of("feature-a", schedule), false);
+
+    var response = endpoint.feature("feature-a");
+
+    assertThat(response.schedule()).isNotNull();
+    assertThat(response.schedule().start()).isEqualTo(LocalDateTime.of(2020, 1, 1, 0, 0));
+    assertThat(response.schedule().end()).isNull();
+    assertTrue(response.schedule().active());
+  }
+
+  @Test
+  void feature_returnsNullSchedule_whenNoScheduleIsConfigured() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
+
+    var response = endpoint.feature("feature-a");
+
+    assertNull(response.schedule());
+  }
+
+  @Test
+  void feature_returnsInactiveSchedule_whenScheduleWindowHasPassed() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
+    // Inactive: end in the past
+    var schedule =
+        new Schedule(
+            null,
+            LocalDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")).plusDays(1),
+            ZoneId.of("UTC"));
+    var fixedClock = Clock.fixed(Instant.now().plusSeconds(86400L * 365 * 100), ZoneId.of("UTC"));
+    var endpointWithFixedClock =
+        new ReactiveFeatureFlagEndpoint(
+            provider,
+            emptyRolloutProvider(),
+            new InMemoryReactiveScheduleProvider(Map.of("feature-a", schedule)),
+            false,
+            eventPublisher,
+            fixedClock);
+
+    var response = endpointWithFixedClock.feature("feature-a");
+
+    assertThat(response.schedule()).isNotNull();
+    assertFalse(response.schedule().active());
+  }
+
+  @Test
+  void features_includesSchedule_whenScheduleIsConfigured() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
+    var schedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    var endpoint = endpointWithSchedule(provider, Map.of("feature-a", schedule), false);
+
+    var response = endpoint.features();
+
+    assertThat(response.features())
+        .filteredOn(f -> f.featureName().equals("feature-a"))
+        .extracting(FeatureFlagEndpointResponse::schedule)
+        .doesNotContainNull();
+  }
+
+  @Test
+  void features_hasNullSchedule_whenNoScheduleConfigured() {
+    var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
+    var endpoint = endpoint(provider, emptyRolloutProvider(), false);
+
+    var response = endpoint.features();
+
+    assertThat(response.features())
+        .filteredOn(f -> f.featureName().equals("feature-a"))
+        .extracting(FeatureFlagEndpointResponse::schedule)
+        .containsOnlyNulls();
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureConfiguration.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureConfiguration.java
@@ -1,7 +1,8 @@
 package net.brightroom.featureflag.core.properties;
 
 /**
- * Configuration for a single feature flag, including its enabled status and rollout percentage.
+ * Configuration for a single feature flag, including its enabled status, rollout percentage, and
+ * optional schedule.
  *
  * <p>Used as the value type for {@code feature-flags.features} in {@link FeatureFlagProperties}.
  *
@@ -13,6 +14,12 @@ package net.brightroom.featureflag.core.properties;
  *     new-feature:
  *       enabled: true
  *       rollout: 50
+ *     christmas-sale:
+ *       enabled: true
+ *       schedule:
+ *         start: "2026-12-25T00:00:00"
+ *         end: "2027-01-05T23:59:59"
+ *         timezone: "Asia/Tokyo"
  *     simple-feature:
  *       enabled: true
  * }</pre>
@@ -21,6 +28,7 @@ public class FeatureConfiguration {
 
   private boolean enabled = true;
   private int rollout = 100;
+  private ScheduleConfiguration schedule;
 
   /**
    * Returns whether this feature is enabled.
@@ -43,6 +51,16 @@ public class FeatureConfiguration {
     return rollout;
   }
 
+  /**
+   * Returns the schedule configuration for this feature, or {@code null} if no schedule is
+   * configured.
+   *
+   * @return the schedule configuration, or {@code null}
+   */
+  public ScheduleConfiguration schedule() {
+    return schedule;
+  }
+
   // for property binding
   void setEnabled(boolean enabled) {
     this.enabled = enabled;
@@ -54,6 +72,11 @@ public class FeatureConfiguration {
       throw new IllegalArgumentException("rollout must be between 0 and 100, but was: " + rollout);
     }
     this.rollout = rollout;
+  }
+
+  // for property binding
+  void setSchedule(ScheduleConfiguration schedule) {
+    this.schedule = schedule;
   }
 
   FeatureConfiguration() {}

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
@@ -2,6 +2,7 @@ package net.brightroom.featureflag.core.properties;
 
 import java.util.HashMap;
 import java.util.Map;
+import net.brightroom.featureflag.core.provider.Schedule;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -59,17 +60,17 @@ public class FeatureFlagProperties {
   }
 
   /**
-   * Returns a map of feature names to their schedule configurations. Features without a schedule
-   * are excluded.
+   * Returns a map of feature names to their schedule value objects. Features without a schedule are
+   * excluded.
    *
-   * @return an immutable map of feature names to their {@link ScheduleConfiguration}
+   * @return an immutable map of feature names to their {@link Schedule}
    */
-  public Map<String, ScheduleConfiguration> schedules() {
-    var result = new HashMap<String, ScheduleConfiguration>();
+  public Map<String, Schedule> schedules() {
+    var result = new HashMap<String, Schedule>();
     features.forEach(
         (name, config) -> {
           if (config.schedule() != null) {
-            result.put(name, config.schedule());
+            result.put(name, config.schedule().toSchedule());
           }
         });
     return Map.copyOf(result);

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
@@ -59,6 +59,23 @@ public class FeatureFlagProperties {
   }
 
   /**
+   * Returns a map of feature names to their schedule configurations. Features without a schedule
+   * are excluded.
+   *
+   * @return an immutable map of feature names to their {@link ScheduleConfiguration}
+   */
+  public Map<String, ScheduleConfiguration> schedules() {
+    var result = new HashMap<String, ScheduleConfiguration>();
+    features.forEach(
+        (name, config) -> {
+          if (config.schedule() != null) {
+            result.put(name, config.schedule());
+          }
+        });
+    return Map.copyOf(result);
+  }
+
+  /**
    * Returns the full feature configuration map.
    *
    * @return an immutable map of feature names to their {@link FeatureConfiguration}

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/ScheduleConfiguration.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/ScheduleConfiguration.java
@@ -1,15 +1,15 @@
 package net.brightroom.featureflag.core.properties;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import net.brightroom.featureflag.core.provider.Schedule;
 
 /**
  * Configuration for the schedule window of a single feature flag.
  *
  * <p>Defines an optional {@code start} and {@code end} time (as {@link LocalDateTime}) and an
- * optional {@code timezone}. When {@link #isActive(Instant)} is called, the instant is converted to
- * the configured timezone (or system default if absent) and compared against the window.
+ * optional {@code timezone}. Use {@link #toSchedule()} to obtain the {@link Schedule} SPI value
+ * object which provides the {@code isActive(Instant)} evaluation logic.
  *
  * <p>Configuration example in {@code application.yml}:
  *
@@ -39,17 +39,12 @@ public class ScheduleConfiguration {
   private ZoneId timezone;
 
   /**
-   * Returns whether the schedule window is active at the given instant.
+   * Converts this property binding object to the SPI value type.
    *
-   * @param now the current instant to check; must not be null
-   * @return {@code true} if {@code now} falls within the configured window, {@code false} otherwise
+   * @return a new {@link Schedule} with the same start, end, and timezone values
    */
-  public boolean isActive(Instant now) {
-    ZoneId zone = timezone != null ? timezone : ZoneId.systemDefault();
-    LocalDateTime localNow = now.atZone(zone).toLocalDateTime();
-    if (start != null && localNow.isBefore(start)) return false;
-    if (end != null && localNow.isAfter(end)) return false;
-    return true;
+  Schedule toSchedule() {
+    return new Schedule(start, end, timezone);
   }
 
   /**
@@ -82,6 +77,10 @@ public class ScheduleConfiguration {
 
   // for property binding
   void setStart(LocalDateTime start) {
+    if (start != null && this.end != null && start.isAfter(this.end)) {
+      throw new IllegalArgumentException(
+          "schedule.start must not be after schedule.end, but start=" + start + " end=" + this.end);
+    }
     this.start = start;
   }
 

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/ScheduleConfiguration.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/ScheduleConfiguration.java
@@ -1,0 +1,106 @@
+package net.brightroom.featureflag.core.properties;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * Configuration for the schedule window of a single feature flag.
+ *
+ * <p>Defines an optional {@code start} and {@code end} time (as {@link LocalDateTime}) and an
+ * optional {@code timezone}. When {@link #isActive(Instant)} is called, the instant is converted to
+ * the configured timezone (or system default if absent) and compared against the window.
+ *
+ * <p>Configuration example in {@code application.yml}:
+ *
+ * <pre>{@code
+ * feature-flags:
+ *   features:
+ *     christmas-sale:
+ *       enabled: true
+ *       schedule:
+ *         start: "2026-12-25T00:00:00"
+ *         end: "2027-01-05T23:59:59"
+ *         timezone: "Asia/Tokyo"
+ * }</pre>
+ *
+ * <ul>
+ *   <li>{@code start} only — the feature is active from {@code start} onward
+ *   <li>{@code end} only — the feature is active until {@code end}
+ *   <li>both — the feature is active between {@code start} and {@code end} (inclusive)
+ *   <li>neither — the feature is always active (equivalent to no schedule)
+ *   <li>{@code timezone} omitted — system default timezone is used
+ * </ul>
+ */
+public class ScheduleConfiguration {
+
+  private LocalDateTime start;
+  private LocalDateTime end;
+  private ZoneId timezone;
+
+  /**
+   * Returns whether the schedule window is active at the given instant.
+   *
+   * @param now the current instant to check; must not be null
+   * @return {@code true} if {@code now} falls within the configured window, {@code false} otherwise
+   */
+  public boolean isActive(Instant now) {
+    ZoneId zone = timezone != null ? timezone : ZoneId.systemDefault();
+    LocalDateTime localNow = now.atZone(zone).toLocalDateTime();
+    if (start != null && localNow.isBefore(start)) return false;
+    if (end != null && localNow.isAfter(end)) return false;
+    return true;
+  }
+
+  /**
+   * Returns the schedule start time, or {@code null} if no start restriction is configured.
+   *
+   * @return the start time, or {@code null}
+   */
+  public LocalDateTime start() {
+    return start;
+  }
+
+  /**
+   * Returns the schedule end time, or {@code null} if no end restriction is configured.
+   *
+   * @return the end time, or {@code null}
+   */
+  public LocalDateTime end() {
+    return end;
+  }
+
+  /**
+   * Returns the timezone used to evaluate start/end times, or {@code null} if the system default
+   * timezone should be used.
+   *
+   * @return the timezone, or {@code null}
+   */
+  public ZoneId timezone() {
+    return timezone;
+  }
+
+  // for property binding
+  void setStart(LocalDateTime start) {
+    this.start = start;
+  }
+
+  // for property binding
+  void setEnd(LocalDateTime end) {
+    if (end != null && this.start != null && end.isBefore(this.start)) {
+      throw new IllegalArgumentException(
+          "schedule.end must not be before schedule.start, but end="
+              + end
+              + " start="
+              + this.start);
+    }
+    this.end = end;
+  }
+
+  // for property binding
+  void setTimezone(ZoneId timezone) {
+    this.timezone = timezone;
+  }
+
+  ScheduleConfiguration() {}
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryReactiveScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryReactiveScheduleProvider.java
@@ -1,7 +1,6 @@
 package net.brightroom.featureflag.core.provider;
 
 import java.util.Map;
-import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
 import reactor.core.publisher.Mono;
 
 /**
@@ -13,7 +12,7 @@ import reactor.core.publisher.Mono;
  */
 public class InMemoryReactiveScheduleProvider implements ReactiveScheduleProvider {
 
-  private final Map<String, ScheduleConfiguration> schedules;
+  private final Map<String, Schedule> schedules;
 
   /**
    * {@inheritDoc}
@@ -21,7 +20,7 @@ public class InMemoryReactiveScheduleProvider implements ReactiveScheduleProvide
    * <p>Returns an empty {@link Mono} for features not present in the schedule map.
    */
   @Override
-  public Mono<ScheduleConfiguration> getSchedule(String featureName) {
+  public Mono<Schedule> getSchedule(String featureName) {
     return Mono.justOrEmpty(schedules.get(featureName));
   }
 
@@ -31,7 +30,7 @@ public class InMemoryReactiveScheduleProvider implements ReactiveScheduleProvide
    * @param schedules a map containing feature flag names as keys and their schedule configurations
    *     as values; copied defensively on construction
    */
-  public InMemoryReactiveScheduleProvider(Map<String, ScheduleConfiguration> schedules) {
+  public InMemoryReactiveScheduleProvider(Map<String, Schedule> schedules) {
     this.schedules = Map.copyOf(schedules);
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryReactiveScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryReactiveScheduleProvider.java
@@ -1,0 +1,37 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
+import reactor.core.publisher.Mono;
+
+/**
+ * An implementation of {@link ReactiveScheduleProvider} that stores schedule configurations in
+ * memory using a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to resolve feature flag schedules
+ * reactively. When a feature has no configured schedule, an empty {@link Mono} is returned.
+ */
+public class InMemoryReactiveScheduleProvider implements ReactiveScheduleProvider {
+
+  private final Map<String, ScheduleConfiguration> schedules;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for features not present in the schedule map.
+   */
+  @Override
+  public Mono<ScheduleConfiguration> getSchedule(String featureName) {
+    return Mono.justOrEmpty(schedules.get(featureName));
+  }
+
+  /**
+   * Constructs an instance with the provided schedule configurations.
+   *
+   * @param schedules a map containing feature flag names as keys and their schedule configurations
+   *     as values; copied defensively on construction
+   */
+  public InMemoryReactiveScheduleProvider(Map<String, ScheduleConfiguration> schedules) {
+    this.schedules = Map.copyOf(schedules);
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryScheduleProvider.java
@@ -1,0 +1,37 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+import java.util.Optional;
+import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
+
+/**
+ * An implementation of {@link ScheduleProvider} that stores schedule configurations in memory using
+ * a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to resolve feature flag schedules.
+ * When a feature has no configured schedule, {@link Optional#empty()} is returned.
+ */
+public class InMemoryScheduleProvider implements ScheduleProvider {
+
+  private final Map<String, ScheduleConfiguration> schedules;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns {@link Optional#empty()} for features not present in the schedule map.
+   */
+  @Override
+  public Optional<ScheduleConfiguration> getSchedule(String featureName) {
+    return Optional.ofNullable(schedules.get(featureName));
+  }
+
+  /**
+   * Constructs an instance with the provided schedule configurations.
+   *
+   * @param schedules a map containing feature flag names as keys and their schedule configurations
+   *     as values; copied defensively on construction
+   */
+  public InMemoryScheduleProvider(Map<String, ScheduleConfiguration> schedules) {
+    this.schedules = Map.copyOf(schedules);
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryScheduleProvider.java
@@ -2,7 +2,6 @@ package net.brightroom.featureflag.core.provider;
 
 import java.util.Map;
 import java.util.Optional;
-import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
 
 /**
  * An implementation of {@link ScheduleProvider} that stores schedule configurations in memory using
@@ -13,7 +12,7 @@ import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
  */
 public class InMemoryScheduleProvider implements ScheduleProvider {
 
-  private final Map<String, ScheduleConfiguration> schedules;
+  private final Map<String, Schedule> schedules;
 
   /**
    * {@inheritDoc}
@@ -21,7 +20,7 @@ public class InMemoryScheduleProvider implements ScheduleProvider {
    * <p>Returns {@link Optional#empty()} for features not present in the schedule map.
    */
   @Override
-  public Optional<ScheduleConfiguration> getSchedule(String featureName) {
+  public Optional<Schedule> getSchedule(String featureName) {
     return Optional.ofNullable(schedules.get(featureName));
   }
 
@@ -31,7 +30,7 @@ public class InMemoryScheduleProvider implements ScheduleProvider {
    * @param schedules a map containing feature flag names as keys and their schedule configurations
    *     as values; copied defensively on construction
    */
-  public InMemoryScheduleProvider(Map<String, ScheduleConfiguration> schedules) {
+  public InMemoryScheduleProvider(Map<String, Schedule> schedules) {
     this.schedules = Map.copyOf(schedules);
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/ReactiveScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/ReactiveScheduleProvider.java
@@ -1,6 +1,5 @@
 package net.brightroom.featureflag.core.provider;
 
-import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
 import reactor.core.publisher.Mono;
 
 /**
@@ -19,8 +18,8 @@ public interface ReactiveScheduleProvider {
    * Returns the configured schedule for the specified feature.
    *
    * @param featureName the name of the feature flag
-   * @return a {@link Mono} emitting the {@link ScheduleConfiguration}, or an empty {@link Mono} if
-   *     no schedule is configured for this feature
+   * @return a {@link Mono} emitting the {@link Schedule}, or an empty {@link Mono} if no schedule
+   *     is configured for this feature
    */
-  Mono<ScheduleConfiguration> getSchedule(String featureName);
+  Mono<Schedule> getSchedule(String featureName);
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/ReactiveScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/ReactiveScheduleProvider.java
@@ -1,0 +1,26 @@
+package net.brightroom.featureflag.core.provider;
+
+import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for resolving the schedule configuration for a given feature flag.
+ *
+ * <p>Implementations provide the configured schedule for each feature flag. When a feature has no
+ * configured schedule, an empty {@link Mono} is returned and the caller treats the schedule as
+ * always active.
+ *
+ * <p>Implement this interface and register it as a Spring bean to override the default in-memory
+ * provider. For example, to read schedules from a reactive data source.
+ */
+public interface ReactiveScheduleProvider {
+
+  /**
+   * Returns the configured schedule for the specified feature.
+   *
+   * @param featureName the name of the feature flag
+   * @return a {@link Mono} emitting the {@link ScheduleConfiguration}, or an empty {@link Mono} if
+   *     no schedule is configured for this feature
+   */
+  Mono<ScheduleConfiguration> getSchedule(String featureName);
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/Schedule.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/Schedule.java
@@ -1,0 +1,51 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An immutable value object representing the schedule window of a feature flag.
+ *
+ * <p>Defines an optional {@code start} and {@code end} time (as {@link LocalDateTime}) and an
+ * optional {@code timezone}. When {@link #isActive(Instant)} is called, the instant is converted to
+ * the configured timezone (or system default if absent) and compared against the window.
+ *
+ * <p>This is the SPI return type for {@link ScheduleProvider} and {@link ReactiveScheduleProvider}.
+ * Custom provider implementations should create instances directly:
+ *
+ * <pre>{@code
+ * return Optional.of(new Schedule(startTime, endTime, ZoneId.of("Asia/Tokyo")));
+ * }</pre>
+ *
+ * <ul>
+ *   <li>{@code start} only — the feature is active from {@code start} onward
+ *   <li>{@code end} only — the feature is active until {@code end}
+ *   <li>both — the feature is active between {@code start} and {@code end} (inclusive)
+ *   <li>neither — the feature is always active (equivalent to no schedule)
+ *   <li>{@code timezone} omitted — system default timezone is used
+ * </ul>
+ *
+ * @param start the schedule start time, or {@code null} if no start restriction is configured
+ * @param end the schedule end time, or {@code null} if no end restriction is configured
+ * @param timezone the timezone used to evaluate start/end times, or {@code null} if the system
+ *     default timezone should be used
+ */
+public record Schedule(
+    @Nullable LocalDateTime start, @Nullable LocalDateTime end, @Nullable ZoneId timezone) {
+
+  /**
+   * Returns whether the schedule window is active at the given instant.
+   *
+   * @param now the current instant to check; must not be null
+   * @return {@code true} if {@code now} falls within the configured window, {@code false} otherwise
+   */
+  public boolean isActive(Instant now) {
+    ZoneId zone = timezone != null ? timezone : ZoneId.systemDefault();
+    LocalDateTime localNow = now.atZone(zone).toLocalDateTime();
+    if (start != null && localNow.isBefore(start)) return false;
+    if (end != null && localNow.isAfter(end)) return false;
+    return true;
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/Schedule.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/Schedule.java
@@ -35,6 +35,13 @@ import org.jspecify.annotations.Nullable;
 public record Schedule(
     @Nullable LocalDateTime start, @Nullable LocalDateTime end, @Nullable ZoneId timezone) {
 
+  public Schedule {
+    if (start != null && end != null && start.isAfter(end)) {
+      throw new IllegalArgumentException(
+          "Schedule start must not be after end, but start=" + start + " end=" + end);
+    }
+  }
+
   /**
    * Returns whether the schedule window is active at the given instant.
    *

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/ScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/ScheduleProvider.java
@@ -1,0 +1,26 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Optional;
+import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
+
+/**
+ * SPI for resolving the schedule configuration for a given feature flag.
+ *
+ * <p>Implementations provide the configured schedule for each feature flag. When a feature has no
+ * configured schedule, {@link Optional#empty()} is returned and the caller treats the schedule as
+ * always active.
+ *
+ * <p>Implement this interface and register it as a Spring bean to override the default in-memory
+ * provider. For example, to read schedules from a database or remote config service.
+ */
+public interface ScheduleProvider {
+
+  /**
+   * Returns the configured schedule for the specified feature.
+   *
+   * @param featureName the name of the feature flag
+   * @return an {@link Optional} containing the {@link ScheduleConfiguration}, or {@link
+   *     Optional#empty()} if no schedule is configured for this feature
+   */
+  Optional<ScheduleConfiguration> getSchedule(String featureName);
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/ScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/ScheduleProvider.java
@@ -1,7 +1,6 @@
 package net.brightroom.featureflag.core.provider;
 
 import java.util.Optional;
-import net.brightroom.featureflag.core.properties.ScheduleConfiguration;
 
 /**
  * SPI for resolving the schedule configuration for a given feature flag.
@@ -19,8 +18,8 @@ public interface ScheduleProvider {
    * Returns the configured schedule for the specified feature.
    *
    * @param featureName the name of the feature flag
-   * @return an {@link Optional} containing the {@link ScheduleConfiguration}, or {@link
-   *     Optional#empty()} if no schedule is configured for this feature
+   * @return an {@link Optional} containing the {@link Schedule}, or {@link Optional#empty()} if no
+   *     schedule is configured for this feature
    */
-  Optional<ScheduleConfiguration> getSchedule(String featureName);
+  Optional<Schedule> getSchedule(String featureName);
 }

--- a/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -51,6 +51,22 @@
       "type": "java.lang.Boolean",
       "description": "Whether condition evaluation errors should cause access denial. Defaults to true (fail-closed): evaluation errors block access. Set to false for fail-open behavior: evaluation errors allow access.",
       "defaultValue": true
+    },
+    {
+      "name": "feature-flags.features.[*].schedule.start",
+      "type": "java.time.LocalDateTime",
+      "description": "The start date-time of the schedule window. The feature is treated as disabled before this time. If omitted, the feature has no start restriction."
+    },
+    {
+      "name": "feature-flags.features.[*].schedule.end",
+      "type": "java.time.LocalDateTime",
+      "description": "The end date-time of the schedule window. The feature is treated as disabled after this time. If omitted, the feature has no end restriction."
+    },
+    {
+      "name": "feature-flags.features.[*].schedule.timezone",
+      "type": "java.time.ZoneId",
+      "description": "The timezone used to evaluate start and end times. If omitted, the system default timezone is used.",
+      "defaultValue": "system default"
     }
   ]
 }

--- a/core/src/test/java/net/brightroom/featureflag/core/properties/FeatureFlagPropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/properties/FeatureFlagPropertiesTest.java
@@ -1,0 +1,76 @@
+package net.brightroom.featureflag.core.properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class FeatureFlagPropertiesTest {
+
+  private FeatureFlagProperties newProperties() {
+    return new FeatureFlagProperties();
+  }
+
+  // --- schedules() ---
+
+  @Test
+  void schedules_returnsEmptyMap_whenNoFeaturesConfigured() {
+    FeatureFlagProperties properties = newProperties();
+
+    assertTrue(properties.schedules().isEmpty());
+  }
+
+  @Test
+  void schedules_excludesFeatures_whenScheduleIsNull() {
+    FeatureFlagProperties properties = newProperties();
+    FeatureConfiguration config = new FeatureConfiguration();
+    // no schedule set → schedule() returns null
+    properties.setFeatures(Map.of("no-schedule-feature", config));
+
+    assertTrue(properties.schedules().isEmpty());
+  }
+
+  @Test
+  void schedules_includesFeature_whenScheduleIsConfigured() {
+    FeatureFlagProperties properties = newProperties();
+    ScheduleConfiguration scheduleConfig = new ScheduleConfiguration();
+    scheduleConfig.setStart(LocalDateTime.of(2026, 6, 15, 10, 0));
+    scheduleConfig.setEnd(LocalDateTime.of(2026, 6, 15, 18, 0));
+
+    FeatureConfiguration config = new FeatureConfiguration();
+    config.setSchedule(scheduleConfig);
+    properties.setFeatures(Map.of("scheduled-feature", config));
+
+    var schedules = properties.schedules();
+    assertEquals(1, schedules.size());
+    assertEquals(LocalDateTime.of(2026, 6, 15, 10, 0), schedules.get("scheduled-feature").start());
+    assertEquals(LocalDateTime.of(2026, 6, 15, 18, 0), schedules.get("scheduled-feature").end());
+  }
+
+  @Test
+  void schedules_mapsMultipleFeatures_whenMultipleSchedulesConfigured() {
+    FeatureFlagProperties properties = newProperties();
+
+    ScheduleConfiguration schedule1 = new ScheduleConfiguration();
+    schedule1.setStart(LocalDateTime.of(2026, 1, 1, 0, 0));
+    FeatureConfiguration config1 = new FeatureConfiguration();
+    config1.setSchedule(schedule1);
+
+    ScheduleConfiguration schedule2 = new ScheduleConfiguration();
+    schedule2.setEnd(LocalDateTime.of(2026, 12, 31, 23, 59));
+    FeatureConfiguration config2 = new FeatureConfiguration();
+    config2.setSchedule(schedule2);
+
+    FeatureConfiguration configNoSchedule = new FeatureConfiguration();
+
+    properties.setFeatures(
+        Map.of("feature-a", config1, "feature-b", config2, "feature-c", configNoSchedule));
+
+    var schedules = properties.schedules();
+    assertEquals(2, schedules.size());
+    assertEquals(LocalDateTime.of(2026, 1, 1, 0, 0), schedules.get("feature-a").start());
+    assertEquals(LocalDateTime.of(2026, 12, 31, 23, 59), schedules.get("feature-b").end());
+  }
+}

--- a/core/src/test/java/net/brightroom/featureflag/core/properties/ScheduleConfigurationTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/properties/ScheduleConfigurationTest.java
@@ -1,0 +1,120 @@
+package net.brightroom.featureflag.core.properties;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class ScheduleConfigurationTest {
+
+  private ScheduleConfiguration newSchedule() {
+    return new ScheduleConfiguration();
+  }
+
+  // --- setEnd() validation ---
+
+  @Test
+  void setEnd_throwsIllegalArgumentException_whenEndIsBeforeStart() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 11, 0)))
+        .withMessageContaining("schedule.end must not be before schedule.start");
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenEndEqualsStart() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0)));
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenEndIsAfterStart() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 13, 0)));
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenStartIsNull() {
+    ScheduleConfiguration schedule = newSchedule();
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 11, 0)));
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenEndIsNull() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(null));
+  }
+
+  // --- setStart() validation (H-1: order-independent validation) ---
+
+  @Test
+  void setStart_throwsIllegalArgumentException_whenStartIsAfterEnd() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 13, 0)))
+        .withMessageContaining("schedule.start must not be after schedule.end");
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenStartEqualsEnd() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0)));
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenStartIsBeforeEnd() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 11, 0)));
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenEndIsNull() {
+    ScheduleConfiguration schedule = newSchedule();
+
+    assertThatNoException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0)));
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenStartIsNull() {
+    ScheduleConfiguration schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setStart(null));
+  }
+
+  // --- toSchedule() ---
+
+  @Test
+  void toSchedule_returnsScheduleWithSameValues() {
+    ScheduleConfiguration config = newSchedule();
+    config.setStart(LocalDateTime.of(2026, 6, 15, 10, 0));
+    config.setEnd(LocalDateTime.of(2026, 6, 15, 18, 0));
+
+    var schedule = config.toSchedule();
+
+    assertEquals(LocalDateTime.of(2026, 6, 15, 10, 0), schedule.start());
+    assertEquals(LocalDateTime.of(2026, 6, 15, 18, 0), schedule.end());
+    assertNull(schedule.timezone());
+  }
+}

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/InMemoryReactiveScheduleProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/InMemoryReactiveScheduleProviderTest.java
@@ -1,0 +1,52 @@
+package net.brightroom.featureflag.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InMemoryReactiveScheduleProviderTest {
+
+  @Test
+  void getSchedule_returnsEmpty_whenFeatureNotPresent() {
+    var provider = new InMemoryReactiveScheduleProvider(Map.of());
+
+    assertTrue(provider.getSchedule("unknown").blockOptional().isEmpty());
+  }
+
+  @Test
+  void getSchedule_returnsSchedule_whenFeaturePresent() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var provider = new InMemoryReactiveScheduleProvider(Map.of("my-feature", schedule));
+
+    var result = provider.getSchedule("my-feature").blockOptional();
+
+    assertTrue(result.isPresent());
+    assertEquals(schedule, result.get());
+  }
+
+  @Test
+  void getSchedule_returnsEmpty_forOtherFeature_whenOnlyOneConfigured() {
+    var schedule = new Schedule(null, LocalDateTime.of(2026, 12, 31, 23, 59), null);
+    var provider = new InMemoryReactiveScheduleProvider(Map.of("feature-a", schedule));
+
+    assertFalse(provider.getSchedule("feature-b").blockOptional().isPresent());
+  }
+
+  @Test
+  void constructor_makesDefensiveCopy_soExternalMapChangesAreIgnored() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var mutableMap = new java.util.HashMap<String, Schedule>();
+    mutableMap.put("feature-a", schedule);
+
+    var provider = new InMemoryReactiveScheduleProvider(mutableMap);
+    mutableMap.clear();
+
+    var result = provider.getSchedule("feature-a").blockOptional();
+    assertTrue(result.isPresent());
+    assertEquals(schedule, result.get());
+  }
+}

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/InMemoryScheduleProviderTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/InMemoryScheduleProviderTest.java
@@ -1,0 +1,51 @@
+package net.brightroom.featureflag.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InMemoryScheduleProviderTest {
+
+  @Test
+  void getSchedule_returnsEmpty_whenFeatureNotPresent() {
+    var provider = new InMemoryScheduleProvider(Map.of());
+
+    assertTrue(provider.getSchedule("unknown").isEmpty());
+  }
+
+  @Test
+  void getSchedule_returnsSchedule_whenFeaturePresent() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var provider = new InMemoryScheduleProvider(Map.of("my-feature", schedule));
+
+    var result = provider.getSchedule("my-feature");
+
+    assertTrue(result.isPresent());
+    assertEquals(schedule, result.get());
+  }
+
+  @Test
+  void getSchedule_returnsEmpty_forOtherFeature_whenOnlyOneConfigured() {
+    var schedule = new Schedule(null, LocalDateTime.of(2026, 12, 31, 23, 59), null);
+    var provider = new InMemoryScheduleProvider(Map.of("feature-a", schedule));
+
+    assertFalse(provider.getSchedule("feature-b").isPresent());
+  }
+
+  @Test
+  void constructor_makesDefensiveCopy_soExternalMapChangesAreIgnored() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var mutableMap = new java.util.HashMap<String, Schedule>();
+    mutableMap.put("feature-a", schedule);
+
+    var provider = new InMemoryScheduleProvider(mutableMap);
+    mutableMap.clear();
+
+    // The provider still returns the schedule despite the external map being cleared
+    assertTrue(provider.getSchedule("feature-a").isPresent());
+  }
+}

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/ScheduleTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/ScheduleTest.java
@@ -1,0 +1,157 @@
+package net.brightroom.featureflag.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class ScheduleTest {
+
+  // Fixed reference instant: 2026-06-15T12:00:00 UTC
+  private final Instant now = Instant.parse("2026-06-15T12:00:00Z");
+
+  // --- start only ---
+
+  @Test
+  void isActive_returnsFalse_whenNowIsBeforeStart() {
+    // start is in the future relative to now
+    Schedule schedule = new Schedule(LocalDateTime.of(2026, 6, 15, 13, 0), null, ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsTrue_whenNowIsAfterStart() {
+    // start is in the past relative to now
+    Schedule schedule = new Schedule(LocalDateTime.of(2026, 6, 15, 11, 0), null, ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- end only ---
+
+  @Test
+  void isActive_returnsTrue_whenNowIsBeforeEnd() {
+    Schedule schedule = new Schedule(null, LocalDateTime.of(2026, 6, 15, 13, 0), ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_whenNowIsAfterEnd() {
+    Schedule schedule = new Schedule(null, LocalDateTime.of(2026, 6, 15, 11, 0), ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  // --- start + end ---
+
+  @Test
+  void isActive_returnsTrue_whenNowIsWithinRange() {
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 11, 0),
+            LocalDateTime.of(2026, 6, 15, 13, 0),
+            ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_whenNowIsBeforeRange() {
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 13, 0),
+            LocalDateTime.of(2026, 6, 15, 15, 0),
+            ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_whenNowIsAfterRange() {
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 9, 0),
+            LocalDateTime.of(2026, 6, 15, 11, 0),
+            ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  // --- neither start nor end ---
+
+  @Test
+  void isActive_returnsTrue_whenBothStartAndEndAreNull() {
+    Schedule schedule = new Schedule(null, null, null);
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- timezone ---
+
+  @Test
+  void isActive_appliesTimezone_whenTimezoneIsConfigured() {
+    // now = 2026-06-15T12:00:00 UTC = 2026-06-15T21:00:00 JST (UTC+9)
+    // schedule: active from 20:00 JST, so 12:00 UTC is after start → active
+    Schedule schedule =
+        new Schedule(LocalDateTime.of(2026, 6, 15, 20, 0), null, ZoneId.of("Asia/Tokyo"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_usingTimezone_whenBeforeStart() {
+    // now = 2026-06-15T12:00:00 UTC = 2026-06-15T21:00:00 JST
+    // schedule: active from 22:00 JST → not yet active
+    Schedule schedule =
+        new Schedule(LocalDateTime.of(2026, 6, 15, 22, 0), null, ZoneId.of("Asia/Tokyo"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_usesSystemDefaultTimezone_whenTimezoneIsNull() {
+    // With null timezone, ZoneId.systemDefault() is used; verify it doesn't throw
+    Schedule schedule = new Schedule(null, null, null);
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- boundary values ---
+
+  @Test
+  void isActive_returnsTrue_whenNowEqualsStart() {
+    // now = 2026-06-15T12:00:00 UTC, start = 2026-06-15T12:00:00 UTC
+    // localNow.isBefore(start) is false at exact equality, so active
+    Schedule schedule = new Schedule(LocalDateTime.of(2026, 6, 15, 12, 0), null, ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsTrue_whenNowEqualsEnd() {
+    // now = 2026-06-15T12:00:00 UTC, end = 2026-06-15T12:00:00 UTC
+    // localNow.isAfter(end) is false at exact equality, so active
+    Schedule schedule = new Schedule(null, LocalDateTime.of(2026, 6, 15, 12, 0), ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- explicit UTC offset ---
+
+  @Test
+  void isActive_worksWithExplicitUtcOffset() {
+    // now = 2026-06-15T12:00:00 UTC = 2026-06-15T09:00:00 UTC-3
+    // schedule: active from 08:00 UTC-3 → active
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 8, 0), null, ZoneId.from(ZoneOffset.ofHours(-3)));
+
+    assertTrue(schedule.isActive(now));
+  }
+}

--- a/core/src/test/java/net/brightroom/featureflag/core/provider/ScheduleTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/provider/ScheduleTest.java
@@ -1,5 +1,7 @@
 package net.brightroom.featureflag.core.provider;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -140,6 +142,43 @@ class ScheduleTest {
     Schedule schedule = new Schedule(null, LocalDateTime.of(2026, 6, 15, 12, 0), ZoneId.of("UTC"));
 
     assertTrue(schedule.isActive(now));
+  }
+
+  // --- constructor validation ---
+
+  @Test
+  void constructor_throwsIllegalArgumentException_whenStartIsAfterEnd() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new Schedule(
+                    LocalDateTime.of(2026, 6, 15, 13, 0),
+                    LocalDateTime.of(2026, 6, 15, 12, 0),
+                    ZoneId.of("UTC")))
+        .withMessageContaining("Schedule start must not be after end");
+  }
+
+  @Test
+  void constructor_doesNotThrow_whenStartEqualsEnd() {
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                new Schedule(
+                    LocalDateTime.of(2026, 6, 15, 12, 0),
+                    LocalDateTime.of(2026, 6, 15, 12, 0),
+                    ZoneId.of("UTC")));
+  }
+
+  @Test
+  void constructor_doesNotThrow_whenStartIsNull() {
+    assertThatNoException()
+        .isThrownBy(() -> new Schedule(null, LocalDateTime.of(2026, 6, 15, 12, 0), null));
+  }
+
+  @Test
+  void constructor_doesNotThrow_whenEndIsNull() {
+    assertThatNoException()
+        .isThrownBy(() -> new Schedule(LocalDateTime.of(2026, 6, 15, 12, 0), null, null));
   }
 
   // --- explicit UTC offset ---

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
@@ -1,11 +1,13 @@
 package net.brightroom.featureflag.webflux.aspect;
 
 import java.lang.reflect.Method;
+import java.time.Clock;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
 import net.brightroom.featureflag.webflux.condition.ServerHttpConditionVariables;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
@@ -40,6 +42,8 @@ public class FeatureFlagAspect {
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
   private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator;
+  private final ReactiveScheduleProvider reactiveScheduleProvider;
+  private final Clock clock;
 
   /**
    * Around advice that checks the feature flag before proceeding with the annotated method.
@@ -69,6 +73,11 @@ public class FeatureFlagAspect {
     int annotationRollout = annotation.rollout();
     Mono<Boolean> enabledMono =
         reactiveFeatureFlagProvider.isFeatureEnabled(featureName).defaultIfEmpty(false);
+    Mono<Boolean> scheduleMono =
+        reactiveScheduleProvider
+            .getSchedule(featureName)
+            .map(schedule -> schedule.isActive(clock.instant()))
+            .defaultIfEmpty(true);
     Mono<Integer> rolloutMono =
         rolloutPercentageProvider
             .getRolloutPercentage(featureName)
@@ -78,12 +87,16 @@ public class FeatureFlagAspect {
 
     if (Mono.class.isAssignableFrom(returnType)) {
       return enabledMono.flatMap(
-          enabled -> handleMonoEnabled(joinPoint, featureName, condition, rolloutMono, enabled));
+          enabled ->
+              handleMonoEnabled(
+                  joinPoint, featureName, condition, rolloutMono, scheduleMono, enabled));
     }
 
     if (Flux.class.isAssignableFrom(returnType)) {
       return enabledMono.flatMapMany(
-          enabled -> handleFluxEnabled(joinPoint, featureName, condition, rolloutMono, enabled));
+          enabled ->
+              handleFluxEnabled(
+                  joinPoint, featureName, condition, rolloutMono, scheduleMono, enabled));
     }
 
     // Non-reactive return type: not supported in WebFlux
@@ -99,15 +112,22 @@ public class FeatureFlagAspect {
       String featureName,
       String condition,
       Mono<Integer> rolloutMono,
+      Mono<Boolean> scheduleMono,
       boolean enabled) {
     if (!enabled) {
       return Mono.error(new FeatureFlagAccessDeniedException(featureName));
     }
-    if (!condition.isEmpty()) {
-      return evaluateConditionForMono(joinPoint, featureName, condition, rolloutMono);
-    }
-    return rolloutMono.flatMap(
-        rollout -> handleMonoRolloutFromContext(joinPoint, featureName, rollout));
+    return scheduleMono.flatMap(
+        active -> {
+          if (!active) {
+            return Mono.error(new FeatureFlagAccessDeniedException(featureName));
+          }
+          if (!condition.isEmpty()) {
+            return evaluateConditionForMono(joinPoint, featureName, condition, rolloutMono);
+          }
+          return rolloutMono.flatMap(
+              rollout -> handleMonoRolloutFromContext(joinPoint, featureName, rollout));
+        });
   }
 
   private Mono<Object> evaluateConditionForMono(
@@ -183,15 +203,22 @@ public class FeatureFlagAspect {
       String featureName,
       String condition,
       Mono<Integer> rolloutMono,
+      Mono<Boolean> scheduleMono,
       boolean enabled) {
     if (!enabled) {
       return Flux.error(new FeatureFlagAccessDeniedException(featureName));
     }
-    if (!condition.isEmpty()) {
-      return evaluateConditionForFlux(joinPoint, featureName, condition, rolloutMono);
-    }
-    return rolloutMono.flatMapMany(
-        rollout -> handleFluxRolloutFromContext(joinPoint, featureName, rollout));
+    return scheduleMono.flatMapMany(
+        active -> {
+          if (!active) {
+            return Flux.error(new FeatureFlagAccessDeniedException(featureName));
+          }
+          if (!condition.isEmpty()) {
+            return evaluateConditionForFlux(joinPoint, featureName, condition, rolloutMono);
+          }
+          return rolloutMono.flatMapMany(
+              rollout -> handleFluxRolloutFromContext(joinPoint, featureName, rollout));
+        });
   }
 
   private Flux<Object> evaluateConditionForFlux(
@@ -327,17 +354,23 @@ public class FeatureFlagAspect {
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature
    * @param conditionEvaluator the reactive evaluator used to evaluate SpEL condition expressions
+   * @param reactiveScheduleProvider the provider used to look up the schedule per feature
+   * @param clock the clock used to obtain the current time for schedule evaluation
    */
   public FeatureFlagAspect(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
       ReactiveRolloutStrategy rolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider rolloutPercentageProvider,
-      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator,
+      ReactiveScheduleProvider reactiveScheduleProvider,
+      Clock clock) {
     this.reactiveFeatureFlagProvider = reactiveFeatureFlagProvider;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
     this.conditionEvaluator = conditionEvaluator;
+    this.reactiveScheduleProvider = reactiveScheduleProvider;
+    this.clock = clock;
   }
 }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.webflux.autoconfigure;
 
+import java.time.Clock;
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
@@ -7,8 +8,10 @@ import net.brightroom.featureflag.core.condition.SpelFeatureFlagConditionEvaluat
 import net.brightroom.featureflag.core.condition.SpelReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.InMemoryReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.InMemoryReactiveScheduleProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
 import net.brightroom.featureflag.webflux.aspect.FeatureFlagAspect;
 import net.brightroom.featureflag.webflux.context.RandomReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
@@ -92,6 +95,18 @@ public class FeatureFlagWebFluxAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  Clock featureFlagClock() {
+    return Clock.systemDefaultZone();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveScheduleProvider.class)
+  ReactiveScheduleProvider reactiveScheduleProvider() {
+    return new InMemoryReactiveScheduleProvider(featureFlagProperties.schedules());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
   FeatureFlagConditionEvaluator featureFlagConditionEvaluator() {
     return new SpelFeatureFlagConditionEvaluator(featureFlagProperties.condition().failOnError());
   }
@@ -125,13 +140,17 @@ public class FeatureFlagWebFluxAutoConfiguration {
       ReactiveRolloutStrategy reactiveRolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
-      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator,
+      ReactiveScheduleProvider reactiveScheduleProvider,
+      Clock clock) {
     return new FeatureFlagAspect(
         reactiveFeatureFlagProvider,
         reactiveRolloutStrategy,
         contextResolver,
         reactiveRolloutPercentageProvider,
-        conditionEvaluator);
+        conditionEvaluator,
+        reactiveScheduleProvider,
+        clock);
   }
 
   @Bean
@@ -148,14 +167,18 @@ public class FeatureFlagWebFluxAutoConfiguration {
       ReactiveRolloutStrategy reactiveRolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
-      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator,
+      ReactiveScheduleProvider reactiveScheduleProvider,
+      Clock clock) {
     return new FeatureFlagHandlerFilterFunction(
         reactiveFeatureFlagProvider,
         accessDeniedHandlerResolution,
         reactiveRolloutStrategy,
         contextResolver,
         reactiveRolloutPercentageProvider,
-        conditionEvaluator);
+        conditionEvaluator,
+        reactiveScheduleProvider,
+        clock);
   }
 
   /**

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,10 +1,12 @@
 package net.brightroom.featureflag.webflux.filter;
 
+import java.time.Clock;
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
 import net.brightroom.featureflag.webflux.condition.ServerHttpConditionVariables;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
@@ -47,6 +49,8 @@ public class FeatureFlagHandlerFilterFunction {
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
   private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator;
+  private final ReactiveScheduleProvider reactiveScheduleProvider;
+  private final Clock clock;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
@@ -146,7 +150,18 @@ public class FeatureFlagHandlerFilterFunction {
     if (!enabled) {
       return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
     }
-    return evaluateCondition(request, next, featureName, condition, rolloutFallback);
+    return reactiveScheduleProvider
+        .getSchedule(featureName)
+        .map(schedule -> schedule.isActive(clock.instant()))
+        .defaultIfEmpty(true)
+        .flatMap(
+            active -> {
+              if (!active) {
+                return resolution.resolve(
+                    request, new FeatureFlagAccessDeniedException(featureName));
+              }
+              return evaluateCondition(request, next, featureName, condition, rolloutFallback);
+            });
   }
 
   private Mono<ServerResponse> evaluateCondition(
@@ -236,6 +251,8 @@ public class FeatureFlagHandlerFilterFunction {
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature
    * @param conditionEvaluator the reactive evaluator used to evaluate SpEL condition expressions
+   * @param reactiveScheduleProvider the provider used to look up the schedule per feature
+   * @param clock the clock used to obtain the current time for schedule evaluation
    */
   public FeatureFlagHandlerFilterFunction(
       ReactiveFeatureFlagProvider reactiveFeatureFlagProvider,
@@ -243,12 +260,16 @@ public class FeatureFlagHandlerFilterFunction {
       ReactiveRolloutStrategy rolloutStrategy,
       ReactiveFeatureFlagContextResolver contextResolver,
       ReactiveRolloutPercentageProvider rolloutPercentageProvider,
-      ReactiveFeatureFlagConditionEvaluator conditionEvaluator) {
+      ReactiveFeatureFlagConditionEvaluator conditionEvaluator,
+      ReactiveScheduleProvider reactiveScheduleProvider,
+      Clock clock) {
     this.reactiveFeatureFlagProvider = reactiveFeatureFlagProvider;
     this.resolution = resolution;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
     this.conditionEvaluator = conditionEvaluator;
+    this.reactiveScheduleProvider = reactiveScheduleProvider;
+    this.clock = clock;
   }
 }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -100,7 +100,8 @@ public class FeatureFlagHandlerFilterFunction {
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag,
    * SpEL condition expression, and rollout percentage.
    *
-   * <p>The evaluation order is: feature enabled check → condition check → rollout check.
+   * <p>The evaluation order is: feature enabled check → schedule check → condition check → rollout
+   * check.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @param condition SpEL expression evaluated against request context; empty string means no

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.time.Clock;
+import java.time.LocalDateTime;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
@@ -15,6 +16,7 @@ import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedExceptio
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
+import net.brightroom.featureflag.core.provider.Schedule;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.rollout.DefaultReactiveRolloutStrategy;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
@@ -122,6 +124,104 @@ class FeatureFlagAspectTest {
     public Mono<String> noAnnotationMethod() {
       return Mono.just("no-annotation");
     }
+  }
+
+  // --- checkSchedule for Mono ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkFeatureFlag_emitsError_whenScheduleIsInactive_forMono() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    // end in the past → inactive
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(inactiveSchedule));
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    StepVerifier.create((Mono<Object>) result)
+        .expectError(FeatureFlagAccessDeniedException.class)
+        .verify();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkFeatureFlag_proceeds_whenScheduleIsActive_forMono() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    // start in the past, no end → active
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(activeSchedule));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    StepVerifier.create((Mono<Object>) result).expectNext("result").verifyComplete();
+  }
+
+  // --- checkSchedule for Flux ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkFeatureFlag_emitsError_whenScheduleIsInactive_forFlux() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("fluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    // end in the past → inactive
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(inactiveSchedule));
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    StepVerifier.create((Flux<Object>) result)
+        .expectError(FeatureFlagAccessDeniedException.class)
+        .verify();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkFeatureFlag_proceeds_whenScheduleIsActive_forFlux() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("fluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    // start in the past, no end → active
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(activeSchedule));
+    when(joinPoint.proceed()).thenReturn(Flux.just("r1", "r2"));
+
+    Object result = aspect.checkFeatureFlag(joinPoint);
+
+    StepVerifier.create((Flux<Object>) result).expectNext("r1", "r2").verifyComplete();
   }
 
   @Test

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
@@ -7,12 +7,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.time.Clock;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.rollout.DefaultReactiveRolloutStrategy;
 import net.brightroom.featureflag.webflux.rollout.ReactiveRolloutStrategy;
@@ -38,13 +40,17 @@ class FeatureFlagAspectTest {
       mock(ReactiveRolloutPercentageProvider.class, invocation -> Mono.empty());
   private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator =
       mock(ReactiveFeatureFlagConditionEvaluator.class);
+  private final ReactiveScheduleProvider reactiveScheduleProvider =
+      mock(ReactiveScheduleProvider.class, invocation -> Mono.empty());
   private final FeatureFlagAspect aspect =
       new FeatureFlagAspect(
           provider,
           new DefaultReactiveRolloutStrategy(),
           contextResolver,
           rolloutPercentageProvider,
-          conditionEvaluator);
+          conditionEvaluator,
+          reactiveScheduleProvider,
+          Clock.systemDefaultZone());
 
   // Aspect with mocked rollout strategy for rollout-specific tests
   private final ReactiveRolloutStrategy rolloutStrategy = mock(ReactiveRolloutStrategy.class);
@@ -54,7 +60,9 @@ class FeatureFlagAspectTest {
           rolloutStrategy,
           contextResolver,
           rolloutPercentageProvider,
-          conditionEvaluator);
+          conditionEvaluator,
+          reactiveScheduleProvider,
+          Clock.systemDefaultZone());
 
   static class TestController {
 

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -9,12 +9,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
+import net.brightroom.featureflag.core.provider.Schedule;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
 import net.brightroom.featureflag.webflux.rollout.DefaultReactiveRolloutStrategy;
@@ -68,6 +70,50 @@ class FeatureFlagHandlerFilterFunctionTest {
           conditionEvaluator,
           reactiveScheduleProvider,
           Clock.systemDefaultZone());
+
+  // --- checkSchedule ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenScheduleIsInactive() {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(Mono.just(true));
+    // end in the past → inactive
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(reactiveScheduleProvider.getSchedule("my-feature"))
+        .thenReturn(Mono.just(inactiveSchedule));
+
+    ServerRequest request = mock(ServerRequest.class);
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(FeatureFlagAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-feature");
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(next);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenScheduleIsActive() {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature")).thenReturn(Mono.empty());
+    // start in the past, no end → active
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(reactiveScheduleProvider.getSchedule("my-feature")).thenReturn(Mono.just(activeSchedule));
+
+    ServerRequest request = mock(ServerRequest.class);
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-feature");
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -8,11 +8,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import net.brightroom.featureflag.core.condition.ReactiveFeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
 import net.brightroom.featureflag.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
 import net.brightroom.featureflag.webflux.rollout.DefaultReactiveRolloutStrategy;
@@ -41,6 +43,8 @@ class FeatureFlagHandlerFilterFunctionTest {
       mock(ReactiveRolloutPercentageProvider.class);
   private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator =
       mock(ReactiveFeatureFlagConditionEvaluator.class);
+  private final ReactiveScheduleProvider reactiveScheduleProvider =
+      mock(ReactiveScheduleProvider.class, invocation -> Mono.empty());
   private final FeatureFlagHandlerFilterFunction filterFunction =
       new FeatureFlagHandlerFilterFunction(
           provider,
@@ -48,7 +52,9 @@ class FeatureFlagHandlerFilterFunctionTest {
           new DefaultReactiveRolloutStrategy(),
           contextResolver,
           rolloutPercentageProvider,
-          conditionEvaluator);
+          conditionEvaluator,
+          reactiveScheduleProvider,
+          Clock.systemDefaultZone());
 
   // Filter function with mocked rollout strategy for rollout-specific tests
   private final ReactiveRolloutStrategy rolloutStrategy = mock(ReactiveRolloutStrategy.class);
@@ -59,7 +65,9 @@ class FeatureFlagHandlerFilterFunctionTest {
           rolloutStrategy,
           contextResolver,
           rolloutPercentageProvider,
-          conditionEvaluator);
+          conditionEvaluator,
+          reactiveScheduleProvider,
+          Clock.systemDefaultZone());
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorScheduleIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorScheduleIntegrationTest.java
@@ -1,0 +1,85 @@
+package net.brightroom.featureflag.webmvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.brightroom.featureflag.webmvc.configuration.FeatureFlagMvcTestAutoConfiguration;
+import net.brightroom.featureflag.webmvc.endpoint.FeatureFlagScheduleController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies schedule-based feature flag control through the full MVC stack:
+ *
+ * <ul>
+ *   <li>Property configuration → {@code InMemoryScheduleProvider} auto-wiring → interceptor → HTTP
+ *       response
+ *   <li>Active schedule (start in the past) → 200 OK
+ *   <li>Inactive schedule (start in the future) → 403 Forbidden
+ *   <li>Timezone-aware schedule → correctly evaluated in the configured timezone
+ * </ul>
+ */
+@WebMvcTest(controllers = FeatureFlagScheduleController.class)
+@Import(FeatureFlagMvcTestAutoConfiguration.class)
+@TestPropertySource(
+    properties = {
+      // active-scheduled-feature: start far in the past → always active
+      "feature-flags.features.active-scheduled-feature.enabled=true",
+      "feature-flags.features.active-scheduled-feature.schedule.start=2020-01-01T00:00:00",
+      // inactive-scheduled-feature: start far in the future → always inactive
+      "feature-flags.features.inactive-scheduled-feature.enabled=true",
+      "feature-flags.features.inactive-scheduled-feature.schedule.start=2099-01-01T00:00:00",
+      // timezone-scheduled-feature: start far in the past with timezone → always active
+      "feature-flags.features.timezone-scheduled-feature.enabled=true",
+      "feature-flags.features.timezone-scheduled-feature.schedule.start=2020-01-01T00:00:00",
+      "feature-flags.features.timezone-scheduled-feature.schedule.timezone=Asia/Tokyo",
+    })
+class FeatureFlagInterceptorScheduleIntegrationTest {
+
+  MockMvc mockMvc;
+
+  @Autowired
+  FeatureFlagInterceptorScheduleIntegrationTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @Test
+  void shouldAllowAccess_whenScheduleIsActive() throws Exception {
+    mockMvc
+        .perform(get("/schedule/active"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+
+  @Test
+  void shouldBlockAccess_whenScheduleIsInactive() throws Exception {
+    mockMvc
+        .perform(get("/schedule/inactive"))
+        .andExpect(status().isForbidden())
+        .andExpect(
+            content()
+                .json(
+                    """
+                    {
+                      "detail" : "Feature 'inactive-scheduled-feature' is not available",
+                      "instance" : "/schedule/inactive",
+                      "status" : 403,
+                      "title" : "Feature flag access denied",
+                      "type" : "https://github.com/bright-room/feature-flag-spring-boot-starter#response-types"
+                    }
+                    """));
+  }
+
+  @Test
+  void shouldAllowAccess_whenScheduleIsActiveWithTimezone() throws Exception {
+    mockMvc
+        .perform(get("/schedule/timezone"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+}

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagScheduleController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagScheduleController.java
@@ -1,0 +1,27 @@
+package net.brightroom.featureflag.webmvc.endpoint;
+
+import net.brightroom.featureflag.core.annotation.FeatureFlag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FeatureFlagScheduleController {
+
+  @GetMapping("/schedule/active")
+  @FeatureFlag("active-scheduled-feature")
+  public String activeSchedule() {
+    return "Allowed";
+  }
+
+  @GetMapping("/schedule/inactive")
+  @FeatureFlag("inactive-scheduled-feature")
+  public String inactiveSchedule() {
+    return "Allowed";
+  }
+
+  @GetMapping("/schedule/timezone")
+  @FeatureFlag("timezone-scheduled-feature")
+  public String timezoneSchedule() {
+    return "Allowed";
+  }
+}

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.webmvc.autoconfigure;
 
+import java.time.Clock;
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
 import net.brightroom.featureflag.core.condition.SpelFeatureFlagConditionEvaluator;
@@ -7,7 +8,9 @@ import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.InMemoryFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.InMemoryRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.InMemoryScheduleProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import net.brightroom.featureflag.core.rollout.DefaultRolloutStrategy;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -78,18 +81,34 @@ public class FeatureFlagMvcAutoConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean
+  Clock featureFlagClock() {
+    return Clock.systemDefaultZone();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ScheduleProvider.class)
+  ScheduleProvider scheduleProvider() {
+    return new InMemoryScheduleProvider(featureFlagProperties.schedules());
+  }
+
+  @Bean
   FeatureFlagInterceptor featureFlagInterceptor(
       FeatureFlagProvider featureFlagProvider,
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
       RolloutPercentageProvider rolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      FeatureFlagConditionEvaluator conditionEvaluator,
+      ScheduleProvider scheduleProvider,
+      Clock clock) {
     return new FeatureFlagInterceptor(
         featureFlagProvider,
         rolloutStrategy,
         contextResolver,
         rolloutPercentageProvider,
-        conditionEvaluator);
+        conditionEvaluator,
+        scheduleProvider,
+        clock);
   }
 
   @Bean
@@ -112,14 +131,18 @@ public class FeatureFlagMvcAutoConfiguration {
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
       RolloutPercentageProvider rolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      FeatureFlagConditionEvaluator conditionEvaluator,
+      ScheduleProvider scheduleProvider,
+      Clock clock) {
     return new FeatureFlagHandlerFilterFunction(
         featureFlagProvider,
         accessDeniedHandlerFilterResolution,
         rolloutStrategy,
         contextResolver,
         rolloutPercentageProvider,
-        conditionEvaluator);
+        conditionEvaluator,
+        scheduleProvider,
+        clock);
   }
 
   /**

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -1,5 +1,6 @@
 package net.brightroom.featureflag.webmvc.filter;
 
+import java.time.Clock;
 import java.util.Optional;
 import net.brightroom.featureflag.core.condition.ConditionVariables;
 import net.brightroom.featureflag.core.condition.FeatureFlagConditionEvaluator;
@@ -7,6 +8,7 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.condition.HttpServletConditionVariables;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -46,6 +48,8 @@ public class FeatureFlagHandlerFilterFunction {
   private final FeatureFlagContextResolver contextResolver;
   private final RolloutPercentageProvider rolloutPercentageProvider;
   private final FeatureFlagConditionEvaluator conditionEvaluator;
+  private final ScheduleProvider scheduleProvider;
+  private final Clock clock;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
@@ -122,6 +126,11 @@ public class FeatureFlagHandlerFilterFunction {
       if (!featureFlagProvider.isFeatureEnabled(featureName)) {
         return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
       }
+      Optional<net.brightroom.featureflag.core.properties.ScheduleConfiguration> schedule =
+          scheduleProvider.getSchedule(featureName);
+      if (schedule.isPresent() && !schedule.get().isActive(clock.instant())) {
+        return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
+      }
       if (condition != null && !condition.isEmpty()) {
         ConditionVariables variables =
             HttpServletConditionVariables.build(request.servletRequest());
@@ -155,6 +164,9 @@ public class FeatureFlagHandlerFilterFunction {
    *     feature; must not be null
    * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions; must not
    *     be null
+   * @param scheduleProvider the provider used to look up the schedule per feature; must not be null
+   * @param clock the clock used to obtain the current time for schedule evaluation; must not be
+   *     null
    */
   public FeatureFlagHandlerFilterFunction(
       FeatureFlagProvider featureFlagProvider,
@@ -162,12 +174,16 @@ public class FeatureFlagHandlerFilterFunction {
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
       RolloutPercentageProvider rolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      FeatureFlagConditionEvaluator conditionEvaluator,
+      ScheduleProvider scheduleProvider,
+      Clock clock) {
     this.featureFlagProvider = featureFlagProvider;
     this.resolution = resolution;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
     this.conditionEvaluator = conditionEvaluator;
+    this.scheduleProvider = scheduleProvider;
+    this.clock = clock;
   }
 }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -99,7 +99,8 @@ public class FeatureFlagHandlerFilterFunction {
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag,
    * SpEL condition expression, and rollout percentage.
    *
-   * <p>The evaluation order is: feature enabled check → condition check → rollout check.
+   * <p>The evaluation order is: feature enabled check → schedule check → condition check → rollout
+   * check.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @param condition SpEL expression evaluated against request context; empty string means no
@@ -126,8 +127,7 @@ public class FeatureFlagHandlerFilterFunction {
       if (!featureFlagProvider.isFeatureEnabled(featureName)) {
         return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
       }
-      Optional<net.brightroom.featureflag.core.properties.ScheduleConfiguration> schedule =
-          scheduleProvider.getSchedule(featureName);
+      var schedule = scheduleProvider.getSchedule(featureName);
       if (schedule.isPresent() && !schedule.get().isActive(clock.instant())) {
         return resolution.resolve(request, new FeatureFlagAccessDeniedException(featureName));
       }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
@@ -2,6 +2,7 @@ package net.brightroom.featureflag.webmvc.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
 import java.util.Optional;
 import net.brightroom.featureflag.core.annotation.FeatureFlag;
 import net.brightroom.featureflag.core.condition.ConditionVariables;
@@ -10,6 +11,7 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.condition.HttpServletConditionVariables;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -32,6 +34,8 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
   private final FeatureFlagContextResolver contextResolver;
   private final RolloutPercentageProvider rolloutPercentageProvider;
   private final FeatureFlagConditionEvaluator conditionEvaluator;
+  private final ScheduleProvider scheduleProvider;
+  private final Clock clock;
 
   /**
    * Creates a new {@link FeatureFlagInterceptor}.
@@ -46,18 +50,26 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
    *     overriding annotation-level values when present; must not be null
    * @param conditionEvaluator the evaluator used to evaluate SpEL condition expressions; must not
    *     be null
+   * @param scheduleProvider the provider that supplies per-flag schedule configurations; must not
+   *     be null
+   * @param clock the clock used to obtain the current time for schedule evaluation; must not be
+   *     null
    */
   public FeatureFlagInterceptor(
       FeatureFlagProvider featureFlagProvider,
       RolloutStrategy rolloutStrategy,
       FeatureFlagContextResolver contextResolver,
       RolloutPercentageProvider rolloutPercentageProvider,
-      FeatureFlagConditionEvaluator conditionEvaluator) {
+      FeatureFlagConditionEvaluator conditionEvaluator,
+      ScheduleProvider scheduleProvider,
+      Clock clock) {
     this.featureFlagProvider = featureFlagProvider;
     this.rolloutStrategy = rolloutStrategy;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
     this.conditionEvaluator = conditionEvaluator;
+    this.scheduleProvider = scheduleProvider;
+    this.clock = clock;
   }
 
   @Override
@@ -75,6 +87,7 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
       if (checkFeatureFlag(methodAnnotation)) {
         throw new FeatureFlagAccessDeniedException(methodAnnotation.value());
       }
+      checkSchedule(methodAnnotation);
       checkCondition(request, methodAnnotation);
       checkRollout(request, methodAnnotation);
       return true;
@@ -88,6 +101,7 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
     if (checkFeatureFlag(classAnnotation)) {
       throw new FeatureFlagAccessDeniedException(classAnnotation.value());
     }
+    checkSchedule(classAnnotation);
     checkCondition(request, classAnnotation);
     checkRollout(request, classAnnotation);
 
@@ -108,6 +122,17 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
 
   private boolean checkFeatureFlag(FeatureFlag annotation) {
     return !featureFlagProvider.isFeatureEnabled(annotation.value());
+  }
+
+  private void checkSchedule(FeatureFlag annotation) {
+    scheduleProvider
+        .getSchedule(annotation.value())
+        .ifPresent(
+            schedule -> {
+              if (!schedule.isActive(clock.instant())) {
+                throw new FeatureFlagAccessDeniedException(annotation.value());
+              }
+            });
   }
 
   private void checkCondition(HttpServletRequest request, FeatureFlag annotation) {

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -19,6 +20,7 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import net.brightroom.featureflag.core.rollout.DefaultRolloutStrategy;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -39,6 +41,8 @@ class FeatureFlagHandlerFilterFunctionTest {
       mock(RolloutPercentageProvider.class);
   private final FeatureFlagConditionEvaluator conditionEvaluator =
       mock(FeatureFlagConditionEvaluator.class);
+  private final ScheduleProvider scheduleProvider =
+      mock(ScheduleProvider.class, invocation -> Optional.empty());
   private final FeatureFlagHandlerFilterFunction filterFunction =
       new FeatureFlagHandlerFilterFunction(
           provider,
@@ -46,7 +50,9 @@ class FeatureFlagHandlerFilterFunctionTest {
           new DefaultRolloutStrategy(),
           contextResolver,
           rolloutPercentageProvider,
-          conditionEvaluator);
+          conditionEvaluator,
+          scheduleProvider,
+          Clock.systemDefaultZone());
 
   // Filter function with a mocked rollout strategy for rollout-specific tests
   private final RolloutStrategy rolloutStrategy = mock(RolloutStrategy.class);
@@ -57,7 +63,9 @@ class FeatureFlagHandlerFilterFunctionTest {
           rolloutStrategy,
           contextResolver,
           rolloutPercentageProvider,
-          conditionEvaluator);
+          conditionEvaluator,
+          scheduleProvider,
+          Clock.systemDefaultZone());
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.Schedule;
 import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import net.brightroom.featureflag.core.rollout.DefaultRolloutStrategy;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
@@ -66,6 +68,51 @@ class FeatureFlagHandlerFilterFunctionTest {
           conditionEvaluator,
           scheduleProvider,
           Clock.systemDefaultZone());
+
+  // --- checkSchedule ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenScheduleIsInactive() throws Exception {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    // end in the past → inactive
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(scheduleProvider.getSchedule("my-feature")).thenReturn(Optional.of(inactiveSchedule));
+
+    ServerRequest request = mock(ServerRequest.class);
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(FeatureFlagAccessDeniedException.class)))
+        .thenReturn(deniedResponse);
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-feature");
+    ServerResponse result = filter.filter(request, next);
+
+    assertThat(result).isEqualTo(deniedResponse);
+    verifyNoInteractions(next);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenScheduleIsActive() throws Exception {
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
+    // start in the past, no end → active
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(scheduleProvider.getSchedule("my-feature")).thenReturn(Optional.of(activeSchedule));
+
+    ServerRequest request = mock(ServerRequest.class);
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(okResponse);
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-feature");
+    ServerResponse result = filter.filter(request, next);
+
+    assertThat(result).isEqualTo(okResponse);
+    verify(next).handle(request);
+  }
 
   @Test
   void of_throwsIllegalArgumentException_whenFeatureNameIsNull() {

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.Schedule;
 import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -69,6 +71,37 @@ class FeatureFlagInterceptorTest {
     when(annotation.condition()).thenReturn(condition);
     when(annotation.rollout()).thenReturn(rollout);
     return annotation;
+  }
+
+  // --- checkSchedule ---
+
+  @Test
+  void preHandle_throwsFeatureFlagAccessDeniedException_whenScheduleIsInactive() {
+    FeatureFlag annotation = featureFlagAnnotation("my-feature", 100);
+    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    // end in the past → inactive
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(scheduleProvider.getSchedule("my-feature")).thenReturn(Optional.of(inactiveSchedule));
+
+    assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+        .isInstanceOf(FeatureFlagAccessDeniedException.class);
+  }
+
+  @Test
+  void preHandle_returnsTrue_whenScheduleIsActive() throws Exception {
+    FeatureFlag annotation = featureFlagAnnotation("my-feature", 100);
+    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
+    when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
+        .thenReturn(OptionalInt.empty());
+    // start in the past, no end → active
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(scheduleProvider.getSchedule("my-feature")).thenReturn(Optional.of(activeSchedule));
+
+    boolean result = interceptor.preHandle(request, response, handlerMethod);
+
+    assertTrue(result);
   }
 
   // --- validateAnnotation ---

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -19,6 +20,7 @@ import net.brightroom.featureflag.core.context.FeatureFlagContext;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ScheduleProvider;
 import net.brightroom.featureflag.core.rollout.RolloutStrategy;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
 import org.junit.jupiter.api.Test;
@@ -33,13 +35,17 @@ class FeatureFlagInterceptorTest {
       mock(RolloutPercentageProvider.class);
   private final FeatureFlagConditionEvaluator conditionEvaluator =
       mock(FeatureFlagConditionEvaluator.class);
+  private final ScheduleProvider scheduleProvider =
+      mock(ScheduleProvider.class, invocation -> Optional.empty());
   private final FeatureFlagInterceptor interceptor =
       new FeatureFlagInterceptor(
           provider,
           rolloutStrategy,
           contextResolver,
           rolloutPercentageProvider,
-          conditionEvaluator);
+          conditionEvaluator,
+          scheduleProvider,
+          Clock.systemDefaultZone());
 
   private final HttpServletRequest request = mock(HttpServletRequest.class);
   private final HttpServletResponse response = mock(HttpServletResponse.class);


### PR DESCRIPTION
## Summary

- **`ScheduleConfiguration`** を新規追加。`start` / `end` / `timezone` フィールドと `isActive(Instant)` メソッドを持つ
- **`FeatureConfiguration`** に `schedule` プロパティを追加し、YAML でスケジュール設定を読み込めるようにした
- **`FeatureFlagProperties.schedules()`** コンビニエンスメソッドを追加
- **`ScheduleProvider` / `ReactiveScheduleProvider`** SPI インターフェースと、それぞれの `InMemory` 実装クラスを追加
- WebMVC（`FeatureFlagInterceptor`、`FeatureFlagHandlerFilterFunction`）と WebFlux（`FeatureFlagAspect`、`FeatureFlagHandlerFilterFunction`）の評価フローに **「feature enabled → schedule active → condition → rollout」** の順でスケジュールチェックを組み込んだ
- `FeatureFlagMvcAutoConfiguration`、`FeatureFlagWebFluxAutoConfiguration`、`FeatureFlagActuatorAutoConfiguration` で `Clock` と `ScheduleProvider` Bean を登録
- Actuator の GET レスポンスに `ScheduleEndpointResponse` フラグメントを追加
- `additional-spring-configuration-metadata.json` に `schedule.start` / `schedule.end` / `schedule.timezone` のメタデータを追加

## Usage

```yaml
feature-flags:
  features:
    christmas-sale:
      enabled: true
      schedule:
        start: "2026-12-25T00:00:00"
        end: "2027-01-05T23:59:59"
        timezone: "Asia/Tokyo"
```

## Test plan

- [x] `./gradlew check` — all modules pass (spotless + unit tests + integration tests)
- [ ] `ScheduleConfiguration.isActive()` のユニットテスト（start のみ / end のみ / 両方 / both null / 境界値）
- [ ] `FeatureFlagInterceptor` の schedule 統合テスト（期間内: 200、期間外: 403）
- [ ] WebFlux `FeatureFlagAspect` / `FeatureFlagHandlerFilterFunction` の schedule 統合テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)