### PR TITLE
Close #238 feat: move condition and rollout from @FeatureFlag annotation to YAML config

### DIFF
--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/autoconfigure/FeatureFlagActuatorAutoConfiguration.java
@@ -11,17 +11,23 @@ import net.brightroom.featureflag.actuator.health.ReactiveFeatureFlagHealthIndic
 import net.brightroom.featureflag.actuator.health.ReactiveHealthDetailsContributor;
 import net.brightroom.featureflag.core.autoconfigure.FeatureFlagAutoConfiguration;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
+import net.brightroom.featureflag.core.provider.ConditionProvider;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.InMemoryReactiveScheduleProvider;
 import net.brightroom.featureflag.core.provider.InMemoryScheduleProvider;
+import net.brightroom.featureflag.core.provider.MutableConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableFeatureFlagProvider;
+import net.brightroom.featureflag.core.provider.MutableInMemoryConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryFeatureFlagProvider;
+import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.MutableReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.MutableRolloutPercentageProvider;
+import net.brightroom.featureflag.core.provider.ReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
@@ -113,6 +119,19 @@ public class FeatureFlagActuatorAutoConfiguration {
     }
 
     /**
+     * Registers a {@link MutableInMemoryConditionProvider} bean when no other {@link
+     * ConditionProvider} bean is already present.
+     *
+     * @return the mutable in-memory condition provider initialized from {@link
+     *     FeatureFlagProperties}
+     */
+    @Bean
+    @ConditionalOnMissingBean(ConditionProvider.class)
+    MutableInMemoryConditionProvider mutableConditionProvider() {
+      return new MutableInMemoryConditionProvider(featureFlagProperties.conditions());
+    }
+
+    /**
      * Registers a {@link Clock} bean when no other {@link Clock} bean is already present.
      *
      * @return the system default clock
@@ -145,6 +164,7 @@ public class FeatureFlagActuatorAutoConfiguration {
      *
      * @param provider the mutable feature flag provider
      * @param rolloutProvider the mutable rollout percentage provider
+     * @param conditionProvider the mutable condition provider
      * @param scheduleProvider the schedule provider
      * @param eventPublisher the publisher used to broadcast flag change events
      * @param clock the clock used for schedule evaluation
@@ -155,12 +175,14 @@ public class FeatureFlagActuatorAutoConfiguration {
     FeatureFlagEndpoint featureFlagEndpoint(
         MutableFeatureFlagProvider provider,
         MutableRolloutPercentageProvider rolloutProvider,
+        MutableConditionProvider conditionProvider,
         ScheduleProvider scheduleProvider,
         ApplicationEventPublisher eventPublisher,
         Clock clock) {
       return new FeatureFlagEndpoint(
           provider,
           rolloutProvider,
+          conditionProvider,
           scheduleProvider,
           featureFlagProperties.defaultEnabled(),
           eventPublisher,
@@ -224,6 +246,19 @@ public class FeatureFlagActuatorAutoConfiguration {
     }
 
     /**
+     * Registers a {@link MutableInMemoryReactiveConditionProvider} bean when no other {@link
+     * ReactiveConditionProvider} bean is already present.
+     *
+     * @return the mutable in-memory reactive condition provider initialized from {@link
+     *     FeatureFlagProperties}
+     */
+    @Bean
+    @ConditionalOnMissingBean(ReactiveConditionProvider.class)
+    MutableInMemoryReactiveConditionProvider mutableReactiveConditionProvider() {
+      return new MutableInMemoryReactiveConditionProvider(featureFlagProperties.conditions());
+    }
+
+    /**
      * Registers a {@link Clock} bean when no other {@link Clock} bean is already present.
      *
      * @return the system default clock
@@ -256,6 +291,7 @@ public class FeatureFlagActuatorAutoConfiguration {
      *
      * @param provider the mutable reactive feature flag provider
      * @param rolloutProvider the mutable reactive rollout percentage provider
+     * @param reactiveConditionProvider the mutable reactive condition provider
      * @param reactiveScheduleProvider the reactive schedule provider
      * @param eventPublisher the publisher used to broadcast flag change events
      * @param clock the clock used for schedule evaluation
@@ -266,12 +302,14 @@ public class FeatureFlagActuatorAutoConfiguration {
     ReactiveFeatureFlagEndpoint reactiveFeatureFlagEndpoint(
         MutableReactiveFeatureFlagProvider provider,
         MutableReactiveRolloutPercentageProvider rolloutProvider,
+        MutableReactiveConditionProvider reactiveConditionProvider,
         ReactiveScheduleProvider reactiveScheduleProvider,
         ApplicationEventPublisher eventPublisher,
         Clock clock) {
       return new ReactiveFeatureFlagEndpoint(
           provider,
           rolloutProvider,
+          reactiveConditionProvider,
           reactiveScheduleProvider,
           featureFlagProperties.defaultEnabled(),
           eventPublisher,

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpoint.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
+import net.brightroom.featureflag.core.provider.MutableConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ScheduleProvider;
@@ -34,6 +35,7 @@ public class FeatureFlagEndpoint {
 
   private final MutableFeatureFlagProvider provider;
   private final MutableRolloutPercentageProvider rolloutProvider;
+  private final MutableConditionProvider conditionProvider;
   private final ScheduleProvider scheduleProvider;
   private final boolean defaultEnabled;
   private final ApplicationEventPublisher eventPublisher;
@@ -66,26 +68,37 @@ public class FeatureFlagEndpoint {
         featureName,
         provider.isFeatureEnabled(featureName),
         rolloutProvider.getRolloutPercentage(featureName).orElse(100),
+        conditionProvider.getCondition(featureName).orElse(null),
         buildScheduleResponse(featureName));
   }
 
   /**
-   * Updates the enabled state and optionally the rollout percentage of a feature flag, then
-   * publishes a {@link FeatureFlagChangedEvent}.
+   * Updates the enabled state and optionally the rollout percentage and condition of a feature
+   * flag, then publishes a {@link FeatureFlagChangedEvent}.
    *
    * <p>If the flag does not exist, it is created with the given state.
    *
    * <p><b>Note:</b> {@link FeatureFlagChangedEvent} is published on every invocation, regardless of
    * whether the value actually changed.
    *
+   * <p>For the {@code condition} parameter:
+   *
+   * <ul>
+   *   <li>{@code null} — condition is not changed
+   *   <li>{@code ""} (empty string) — condition is removed
+   *   <li>any other string — condition is set to the given value
+   * </ul>
+   *
    * @param featureName the name of the feature flag to update
    * @param enabled the new enabled state
    * @param rollout the new rollout percentage (0–100), or {@code null} to leave unchanged
+   * @param condition the new condition expression, {@code ""} to remove, or {@code null} to leave
+   *     unchanged
    * @return a response reflecting the updated state of all flags
    */
   @WriteOperation
   public FeatureFlagsEndpointResponse updateFeature(
-      String featureName, boolean enabled, @Nullable Integer rollout) {
+      String featureName, boolean enabled, @Nullable Integer rollout, @Nullable String condition) {
     if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException("featureName must not be null or blank");
     }
@@ -96,12 +109,20 @@ public class FeatureFlagEndpoint {
     if (rollout != null) {
       rolloutProvider.setRolloutPercentage(featureName, rollout);
     }
-    eventPublisher.publishEvent(new FeatureFlagChangedEvent(this, featureName, enabled, rollout));
+    if (condition != null) {
+      if (condition.isEmpty()) {
+        conditionProvider.removeCondition(featureName);
+      } else {
+        conditionProvider.setCondition(featureName, condition);
+      }
+    }
+    eventPublisher.publishEvent(
+        new FeatureFlagChangedEvent(this, featureName, enabled, rollout, condition));
     return buildFlagsResponse();
   }
 
   /**
-   * Removes a feature flag and its associated rollout percentage.
+   * Removes a feature flag and its associated rollout percentage and condition.
    *
    * <p>A {@link FeatureFlagRemovedEvent} is published only if the flag actually existed. This
    * operation is idempotent: deleting a non-existent flag is a no-op and still returns 204 No
@@ -117,6 +138,7 @@ public class FeatureFlagEndpoint {
     }
     boolean removed = provider.removeFeature(featureName);
     rolloutProvider.removeRolloutPercentage(featureName);
+    conditionProvider.removeCondition(featureName);
     if (removed) {
       eventPublisher.publishEvent(new FeatureFlagRemovedEvent(this, featureName));
     }
@@ -124,6 +146,7 @@ public class FeatureFlagEndpoint {
 
   private FeatureFlagsEndpointResponse buildFlagsResponse() {
     var rolloutPercentages = rolloutProvider.getRolloutPercentages();
+    var conditions = conditionProvider.getConditions();
     var featureList =
         provider.getFeatures().entrySet().stream()
             .sorted(Map.Entry.comparingByKey())
@@ -133,6 +156,7 @@ public class FeatureFlagEndpoint {
                         e.getKey(),
                         e.getValue(),
                         rolloutPercentages.getOrDefault(e.getKey(), 100),
+                        conditions.getOrDefault(e.getKey(), null),
                         buildScheduleResponse(e.getKey())))
             .toList();
     return new FeatureFlagsEndpointResponse(featureList, defaultEnabled);
@@ -157,6 +181,7 @@ public class FeatureFlagEndpoint {
    *
    * @param provider the mutable feature flag provider
    * @param rolloutProvider the mutable rollout percentage provider
+   * @param conditionProvider the mutable condition provider
    * @param scheduleProvider the schedule provider used to look up schedules per feature
    * @param defaultEnabled the default-enabled value to include in responses
    * @param eventPublisher the publisher used to broadcast flag change events
@@ -165,12 +190,14 @@ public class FeatureFlagEndpoint {
   public FeatureFlagEndpoint(
       MutableFeatureFlagProvider provider,
       MutableRolloutPercentageProvider rolloutProvider,
+      MutableConditionProvider conditionProvider,
       ScheduleProvider scheduleProvider,
       boolean defaultEnabled,
       ApplicationEventPublisher eventPublisher,
       Clock clock) {
     this.provider = provider;
     this.rolloutProvider = rolloutProvider;
+    this.conditionProvider = conditionProvider;
     this.scheduleProvider = scheduleProvider;
     this.defaultEnabled = defaultEnabled;
     this.eventPublisher = eventPublisher;

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointResponse.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointResponse.java
@@ -10,11 +10,27 @@ import org.jspecify.annotations.Nullable;
  * @param featureName the name of the feature flag
  * @param enabled the current enabled state of the feature flag
  * @param rollout the current rollout percentage (0–100) of the feature flag
+ * @param condition the current condition expression, or {@code null} if no condition is configured
  * @param schedule the schedule configuration for this flag, or {@code null} if no schedule is
  *     configured
  */
 public record FeatureFlagEndpointResponse(
-    String featureName, boolean enabled, int rollout, @Nullable ScheduleEndpointResponse schedule) {
+    String featureName,
+    boolean enabled,
+    int rollout,
+    @Nullable String condition,
+    @Nullable ScheduleEndpointResponse schedule) {
+
+  /**
+   * Creates a response without condition or schedule information.
+   *
+   * @param featureName the name of the feature flag
+   * @param enabled the current enabled state of the feature flag
+   * @param rollout the current rollout percentage (0–100) of the feature flag
+   */
+  public FeatureFlagEndpointResponse(String featureName, boolean enabled, int rollout) {
+    this(featureName, enabled, rollout, null, null);
+  }
 
   /**
    * Creates a response without schedule information.
@@ -22,8 +38,11 @@ public record FeatureFlagEndpointResponse(
    * @param featureName the name of the feature flag
    * @param enabled the current enabled state of the feature flag
    * @param rollout the current rollout percentage (0–100) of the feature flag
+   * @param condition the current condition expression, or {@code null} if no condition is
+   *     configured
    */
-  public FeatureFlagEndpointResponse(String featureName, boolean enabled, int rollout) {
-    this(featureName, enabled, rollout, null);
+  public FeatureFlagEndpointResponse(
+      String featureName, boolean enabled, int rollout, @Nullable String condition) {
+    this(featureName, enabled, rollout, condition, null);
   }
 }

--- a/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
+++ b/actuator/src/main/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpoint.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
+import net.brightroom.featureflag.core.provider.MutableReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
@@ -37,6 +38,7 @@ public class ReactiveFeatureFlagEndpoint {
 
   private final MutableReactiveFeatureFlagProvider provider;
   private final MutableReactiveRolloutPercentageProvider rolloutProvider;
+  private final MutableReactiveConditionProvider conditionProvider;
   private final ReactiveScheduleProvider reactiveScheduleProvider;
   private final boolean defaultEnabled;
   private final ApplicationEventPublisher eventPublisher;
@@ -67,27 +69,42 @@ public class ReactiveFeatureFlagEndpoint {
     }
     var enabled = provider.isFeatureEnabled(featureName).block();
     var rollout = rolloutProvider.getRolloutPercentage(featureName).blockOptional().orElse(100);
+    var condition = conditionProvider.getCondition(featureName).blockOptional().orElse(null);
     return new FeatureFlagEndpointResponse(
-        featureName, Boolean.TRUE.equals(enabled), rollout, buildScheduleResponse(featureName));
+        featureName,
+        Boolean.TRUE.equals(enabled),
+        rollout,
+        condition,
+        buildScheduleResponse(featureName));
   }
 
   /**
-   * Updates the enabled state and optionally the rollout percentage of a feature flag, then
-   * publishes a {@link FeatureFlagChangedEvent}.
+   * Updates the enabled state and optionally the rollout percentage and condition of a feature
+   * flag, then publishes a {@link FeatureFlagChangedEvent}.
    *
    * <p>If the flag does not exist, it is created with the given state.
    *
    * <p><b>Note:</b> {@link FeatureFlagChangedEvent} is published on every invocation, regardless of
    * whether the value actually changed.
    *
+   * <p>For the {@code condition} parameter:
+   *
+   * <ul>
+   *   <li>{@code null} — condition is not changed
+   *   <li>{@code ""} (empty string) — condition is removed
+   *   <li>any other string — condition is set to the given value
+   * </ul>
+   *
    * @param featureName the name of the feature flag to update
    * @param enabled the new enabled state
    * @param rollout the new rollout percentage (0–100), or {@code null} to leave unchanged
+   * @param condition the new condition expression, {@code ""} to remove, or {@code null} to leave
+   *     unchanged
    * @return a response reflecting the updated state of all flags
    */
   @WriteOperation
   public FeatureFlagsEndpointResponse updateFeature(
-      String featureName, boolean enabled, @Nullable Integer rollout) {
+      String featureName, boolean enabled, @Nullable Integer rollout, @Nullable String condition) {
     if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException("featureName must not be null or blank");
     }
@@ -98,12 +115,20 @@ public class ReactiveFeatureFlagEndpoint {
     if (rollout != null) {
       rolloutProvider.setRolloutPercentage(featureName, rollout).block();
     }
-    eventPublisher.publishEvent(new FeatureFlagChangedEvent(this, featureName, enabled, rollout));
+    if (condition != null) {
+      if (condition.isEmpty()) {
+        conditionProvider.removeCondition(featureName).block();
+      } else {
+        conditionProvider.setCondition(featureName, condition).block();
+      }
+    }
+    eventPublisher.publishEvent(
+        new FeatureFlagChangedEvent(this, featureName, enabled, rollout, condition));
     return buildFlagsResponse();
   }
 
   /**
-   * Removes a feature flag and its associated rollout percentage.
+   * Removes a feature flag and its associated rollout percentage and condition.
    *
    * <p>A {@link FeatureFlagRemovedEvent} is published only if the flag actually existed. This
    * operation is idempotent: deleting a non-existent flag is a no-op and still returns 204 No
@@ -119,6 +144,7 @@ public class ReactiveFeatureFlagEndpoint {
     }
     Boolean removed = provider.removeFeature(featureName).block();
     rolloutProvider.removeRolloutPercentage(featureName).block();
+    conditionProvider.removeCondition(featureName).block();
     if (Boolean.TRUE.equals(removed)) {
       eventPublisher.publishEvent(new FeatureFlagRemovedEvent(this, featureName));
     }
@@ -131,6 +157,7 @@ public class ReactiveFeatureFlagEndpoint {
     }
     var rolloutPercentages =
         rolloutProvider.getRolloutPercentages().blockOptional().orElse(Map.of());
+    var conditions = conditionProvider.getConditions().blockOptional().orElse(Map.of());
     var featureList =
         features.entrySet().stream()
             .sorted(Map.Entry.comparingByKey())
@@ -140,6 +167,7 @@ public class ReactiveFeatureFlagEndpoint {
                         e.getKey(),
                         e.getValue(),
                         rolloutPercentages.getOrDefault(e.getKey(), 100),
+                        conditions.getOrDefault(e.getKey(), null),
                         buildScheduleResponse(e.getKey())))
             .toList();
     return new FeatureFlagsEndpointResponse(featureList, defaultEnabled);
@@ -161,6 +189,7 @@ public class ReactiveFeatureFlagEndpoint {
    *
    * @param provider the mutable reactive feature flag provider
    * @param rolloutProvider the mutable reactive rollout percentage provider
+   * @param conditionProvider the mutable reactive condition provider
    * @param reactiveScheduleProvider the reactive schedule provider used to look up schedules per
    *     feature
    * @param defaultEnabled the default-enabled value to include in responses
@@ -170,12 +199,14 @@ public class ReactiveFeatureFlagEndpoint {
   public ReactiveFeatureFlagEndpoint(
       MutableReactiveFeatureFlagProvider provider,
       MutableReactiveRolloutPercentageProvider rolloutProvider,
+      MutableReactiveConditionProvider conditionProvider,
       ReactiveScheduleProvider reactiveScheduleProvider,
       boolean defaultEnabled,
       ApplicationEventPublisher eventPublisher,
       Clock clock) {
     this.provider = provider;
     this.rolloutProvider = rolloutProvider;
+    this.conditionProvider = conditionProvider;
     this.reactiveScheduleProvider = reactiveScheduleProvider;
     this.defaultEnabled = defaultEnabled;
     this.eventPublisher = eventPublisher;

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/FeatureFlagEndpointTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
 import net.brightroom.featureflag.core.provider.InMemoryScheduleProvider;
+import net.brightroom.featureflag.core.provider.MutableInMemoryConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.Schedule;
@@ -40,6 +41,10 @@ class FeatureFlagEndpointTest {
     return new MutableInMemoryRolloutPercentageProvider(Map.of());
   }
 
+  private MutableInMemoryConditionProvider emptyConditionProvider() {
+    return new MutableInMemoryConditionProvider(Map.of());
+  }
+
   private InMemoryScheduleProvider emptyScheduleProvider() {
     return new InMemoryScheduleProvider(Map.of());
   }
@@ -49,7 +54,13 @@ class FeatureFlagEndpointTest {
       MutableInMemoryRolloutPercentageProvider rolloutProvider,
       boolean defaultEnabled) {
     return new FeatureFlagEndpoint(
-        provider, rolloutProvider, emptyScheduleProvider(), defaultEnabled, eventPublisher, clock);
+        provider,
+        rolloutProvider,
+        emptyConditionProvider(),
+        emptyScheduleProvider(),
+        defaultEnabled,
+        eventPublisher,
+        clock);
   }
 
   private FeatureFlagEndpoint endpointWithSchedule(
@@ -59,6 +70,7 @@ class FeatureFlagEndpointTest {
     return new FeatureFlagEndpoint(
         provider,
         emptyRolloutProvider(),
+        emptyConditionProvider(),
         new InMemoryScheduleProvider(schedules),
         defaultEnabled,
         eventPublisher,
@@ -85,7 +97,7 @@ class FeatureFlagEndpointTest {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    var response = endpoint.updateFeature("feature-a", false, null);
+    var response = endpoint.updateFeature("feature-a", false, null, null);
 
     assertThat(response.features())
         .filteredOn(f -> f.featureName().equals("feature-a"))
@@ -98,7 +110,7 @@ class FeatureFlagEndpointTest {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    endpoint.updateFeature("feature-a", false, null);
+    endpoint.updateFeature("feature-a", false, null, null);
 
     var captor = ArgumentCaptor.forClass(FeatureFlagChangedEvent.class);
     verify(eventPublisher).publishEvent(captor.capture());
@@ -111,7 +123,7 @@ class FeatureFlagEndpointTest {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of(), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    var response = endpoint.updateFeature("new-flag", true, null);
+    var response = endpoint.updateFeature("new-flag", true, null, null);
 
     assertThat(response.features())
         .filteredOn(f -> f.featureName().equals("new-flag"))
@@ -135,7 +147,7 @@ class FeatureFlagEndpointTest {
         new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true, "feature-b", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    var response = endpoint.updateFeature("feature-a", false, null);
+    var response = endpoint.updateFeature("feature-a", false, null, null);
 
     assertEquals(2, response.features().size());
     assertThat(response.features())
@@ -149,7 +161,7 @@ class FeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature(null, true, null))
+        .isThrownBy(() -> endpoint.updateFeature(null, true, null, null))
         .withMessageContaining("featureName must not be null or blank");
   }
 
@@ -159,7 +171,7 @@ class FeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("", true, null))
+        .isThrownBy(() -> endpoint.updateFeature("", true, null, null))
         .withMessageContaining("featureName must not be null or blank");
   }
 
@@ -169,7 +181,7 @@ class FeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("   ", true, null))
+        .isThrownBy(() -> endpoint.updateFeature("   ", true, null, null))
         .withMessageContaining("featureName must not be null or blank");
   }
 
@@ -271,7 +283,7 @@ class FeatureFlagEndpointTest {
     var rolloutProvider = new MutableInMemoryRolloutPercentageProvider(Map.of());
     var endpoint = endpoint(provider, rolloutProvider, false);
 
-    var response = endpoint.updateFeature("feature-a", true, 50);
+    var response = endpoint.updateFeature("feature-a", true, 50, null);
 
     assertThat(response.features())
         .filteredOn(f -> f.featureName().equals("feature-a"))
@@ -284,7 +296,7 @@ class FeatureFlagEndpointTest {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    endpoint.updateFeature("feature-a", true, 60);
+    endpoint.updateFeature("feature-a", true, 60, null);
 
     var captor = ArgumentCaptor.forClass(FeatureFlagChangedEvent.class);
     verify(eventPublisher).publishEvent(captor.capture());
@@ -297,7 +309,7 @@ class FeatureFlagEndpointTest {
     var provider = new MutableInMemoryFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    endpoint.updateFeature("feature-a", true, null);
+    endpoint.updateFeature("feature-a", true, null, null);
 
     var captor = ArgumentCaptor.forClass(FeatureFlagChangedEvent.class);
     verify(eventPublisher).publishEvent(captor.capture());
@@ -310,7 +322,7 @@ class FeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, -1))
+        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, -1, null))
         .withMessageContaining("rollout must be between 0 and 100");
   }
 
@@ -320,7 +332,7 @@ class FeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, 101))
+        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, 101, null))
         .withMessageContaining("rollout must be between 0 and 100");
   }
 
@@ -330,8 +342,8 @@ class FeatureFlagEndpointTest {
     var rolloutProvider = new MutableInMemoryRolloutPercentageProvider(Map.of());
     var endpoint = endpoint(provider, rolloutProvider, false);
 
-    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 0));
-    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 100));
+    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 0, null));
+    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 100, null));
   }
 
   @Test
@@ -465,6 +477,7 @@ class FeatureFlagEndpointTest {
         new FeatureFlagEndpoint(
             provider,
             emptyRolloutProvider(),
+            emptyConditionProvider(),
             new InMemoryScheduleProvider(Map.of("feature-a", schedule)),
             false,
             eventPublisher,

--- a/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpointTest.java
+++ b/actuator/src/test/java/net/brightroom/featureflag/actuator/endpoint/ReactiveFeatureFlagEndpointTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import net.brightroom.featureflag.core.event.FeatureFlagChangedEvent;
 import net.brightroom.featureflag.core.event.FeatureFlagRemovedEvent;
 import net.brightroom.featureflag.core.provider.InMemoryReactiveScheduleProvider;
+import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.MutableInMemoryReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.MutableReactiveFeatureFlagProvider;
@@ -44,6 +45,10 @@ class ReactiveFeatureFlagEndpointTest {
     return new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
   }
 
+  private MutableInMemoryReactiveConditionProvider emptyConditionProvider() {
+    return new MutableInMemoryReactiveConditionProvider(Map.of());
+  }
+
   private InMemoryReactiveScheduleProvider emptyScheduleProvider() {
     return new InMemoryReactiveScheduleProvider(Map.of());
   }
@@ -53,7 +58,13 @@ class ReactiveFeatureFlagEndpointTest {
       MutableInMemoryReactiveRolloutPercentageProvider rolloutProvider,
       boolean defaultEnabled) {
     return new ReactiveFeatureFlagEndpoint(
-        provider, rolloutProvider, emptyScheduleProvider(), defaultEnabled, eventPublisher, clock);
+        provider,
+        rolloutProvider,
+        emptyConditionProvider(),
+        emptyScheduleProvider(),
+        defaultEnabled,
+        eventPublisher,
+        clock);
   }
 
   private ReactiveFeatureFlagEndpoint endpointWithSchedule(
@@ -63,6 +74,7 @@ class ReactiveFeatureFlagEndpointTest {
     return new ReactiveFeatureFlagEndpoint(
         provider,
         emptyRolloutProvider(),
+        emptyConditionProvider(),
         new InMemoryReactiveScheduleProvider(schedules),
         defaultEnabled,
         eventPublisher,
@@ -89,7 +101,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    var response = endpoint.updateFeature("feature-a", false, null);
+    var response = endpoint.updateFeature("feature-a", false, null, null);
 
     assertThat(response.features())
         .filteredOn(f -> f.featureName().equals("feature-a"))
@@ -102,7 +114,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    endpoint.updateFeature("feature-a", false, null);
+    endpoint.updateFeature("feature-a", false, null, null);
 
     var captor = ArgumentCaptor.forClass(FeatureFlagChangedEvent.class);
     verify(eventPublisher).publishEvent(captor.capture());
@@ -115,7 +127,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of(), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    var response = endpoint.updateFeature("new-flag", true, null);
+    var response = endpoint.updateFeature("new-flag", true, null, null);
 
     assertThat(response.features())
         .filteredOn(f -> f.featureName().equals("new-flag"))
@@ -140,7 +152,7 @@ class ReactiveFeatureFlagEndpointTest {
             Map.of("feature-a", true, "feature-b", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    var response = endpoint.updateFeature("feature-a", false, null);
+    var response = endpoint.updateFeature("feature-a", false, null, null);
 
     assertEquals(2, response.features().size());
     assertThat(response.features())
@@ -154,7 +166,7 @@ class ReactiveFeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature(null, true, null))
+        .isThrownBy(() -> endpoint.updateFeature(null, true, null, null))
         .withMessageContaining("featureName must not be null or blank");
   }
 
@@ -164,7 +176,7 @@ class ReactiveFeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("", true, null))
+        .isThrownBy(() -> endpoint.updateFeature("", true, null, null))
         .withMessageContaining("featureName must not be null or blank");
   }
 
@@ -174,7 +186,7 @@ class ReactiveFeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("   ", true, null))
+        .isThrownBy(() -> endpoint.updateFeature("   ", true, null, null))
         .withMessageContaining("featureName must not be null or blank");
   }
 
@@ -231,6 +243,7 @@ class ReactiveFeatureFlagEndpointTest {
         new ReactiveFeatureFlagEndpoint(
             provider,
             emptyRolloutProvider(),
+            emptyConditionProvider(),
             emptyScheduleProvider(),
             false,
             eventPublisher,
@@ -298,7 +311,7 @@ class ReactiveFeatureFlagEndpointTest {
     var rolloutProvider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
     var endpoint = endpoint(provider, rolloutProvider, false);
 
-    var response = endpoint.updateFeature("feature-a", true, 50);
+    var response = endpoint.updateFeature("feature-a", true, 50, null);
 
     assertThat(response.features())
         .filteredOn(f -> f.featureName().equals("feature-a"))
@@ -311,7 +324,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    endpoint.updateFeature("feature-a", true, 60);
+    endpoint.updateFeature("feature-a", true, 60, null);
 
     var captor = ArgumentCaptor.forClass(FeatureFlagChangedEvent.class);
     verify(eventPublisher).publishEvent(captor.capture());
@@ -324,7 +337,7 @@ class ReactiveFeatureFlagEndpointTest {
     var provider = new MutableInMemoryReactiveFeatureFlagProvider(Map.of("feature-a", true), false);
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
-    endpoint.updateFeature("feature-a", true, null);
+    endpoint.updateFeature("feature-a", true, null, null);
 
     var captor = ArgumentCaptor.forClass(FeatureFlagChangedEvent.class);
     verify(eventPublisher).publishEvent(captor.capture());
@@ -337,7 +350,7 @@ class ReactiveFeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, -1))
+        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, -1, null))
         .withMessageContaining("rollout must be between 0 and 100");
   }
 
@@ -347,7 +360,7 @@ class ReactiveFeatureFlagEndpointTest {
     var endpoint = endpoint(provider, emptyRolloutProvider(), false);
 
     assertThatIllegalArgumentException()
-        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, 101))
+        .isThrownBy(() -> endpoint.updateFeature("feature-a", true, 101, null))
         .withMessageContaining("rollout must be between 0 and 100");
   }
 
@@ -357,8 +370,8 @@ class ReactiveFeatureFlagEndpointTest {
     var rolloutProvider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
     var endpoint = endpoint(provider, rolloutProvider, false);
 
-    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 0));
-    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 100));
+    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 0, null));
+    assertThatNoException().isThrownBy(() -> endpoint.updateFeature("feature-a", true, 100, null));
   }
 
   @Test
@@ -492,6 +505,7 @@ class ReactiveFeatureFlagEndpointTest {
         new ReactiveFeatureFlagEndpoint(
             provider,
             emptyRolloutProvider(),
+            emptyConditionProvider(),
             new InMemoryReactiveScheduleProvider(Map.of("feature-a", schedule)),
             false,
             eventPublisher,

--- a/core/src/main/java/net/brightroom/featureflag/core/annotation/FeatureFlag.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/annotation/FeatureFlag.java
@@ -10,20 +10,34 @@ import java.lang.annotation.Target;
  * Feature flag annotation to control access to specific features. This annotation can be applied at
  * both method and class levels to manage feature availability.
  *
+ * <p>Condition expressions and rollout percentages are configured via {@code
+ * feature-flags.features.<name>} in {@code application.yaml} rather than on the annotation itself.
+ *
  * <p>Usage examples:
  *
  * <pre>{@code
  * // Method level
- * {@literal @}FeatureFlag(value = "new-api")
+ * {@literal @}FeatureFlag("new-api")
  * public void newFeature() {
  *     // This method will only be accessible if "new-api" feature is enabled
  * }
  *
  * // Class level
- * {@literal @}FeatureFlag(value = "beta-features")
+ * {@literal @}FeatureFlag("beta-features")
  * public class BetaController {
  *     // All methods in this class will only be accessible if "beta-features" is enabled
  * }
+ * }</pre>
+ *
+ * <p>To configure a condition or rollout percentage, use {@code application.yaml}:
+ *
+ * <pre>{@code
+ * feature-flags:
+ *   features:
+ *     new-api:
+ *       enabled: true
+ *       condition: "headers['X-Beta'] != null"
+ *       rollout: 50
  * }</pre>
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
@@ -43,37 +57,4 @@ public @interface FeatureFlag {
    * @return the identifier of the feature flag; must be a non-empty string
    */
   String value();
-
-  /**
-   * SpEL condition expression evaluated against request context.
-   *
-   * <p>When non-empty, the feature is enabled only if the expression evaluates to {@code true}.
-   *
-   * <p>Available variables:
-   *
-   * <ul>
-   *   <li>{@code headers} — request headers as {@code Map<String, String>}
-   *   <li>{@code params} — query parameters as {@code Map<String, String>}
-   *   <li>{@code cookies} — cookies as {@code Map<String, String>}
-   *   <li>{@code path} — request path as {@code String}
-   *   <li>{@code method} — HTTP method as {@code String}
-   *   <li>{@code remoteAddress} — client IP as {@code String}
-   * </ul>
-   *
-   * <p>Example: {@code @FeatureFlag(value = "beta", condition = "headers['X-Beta'] != null")}
-   *
-   * @return SpEL expression; empty string (default) means no condition
-   */
-  String condition() default "";
-
-  /**
-   * Rollout percentage (0–100). 100 means fully enabled (default).
-   *
-   * <p>When less than 100, the feature is enabled only for a percentage of requests (or users, if a
-   * sticky {@code FeatureFlagContextResolver} is provided). When 0, the feature is effectively
-   * disabled for all requests even if the flag itself is enabled.
-   *
-   * @return the rollout percentage; must be between 0 and 100 inclusive
-   */
-  int rollout() default 100;
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/event/FeatureFlagChangedEvent.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/event/FeatureFlagChangedEvent.java
@@ -4,7 +4,8 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEvent;
 
 /**
- * Event published when a feature flag's enabled state or rollout percentage is changed at runtime.
+ * Event published when a feature flag's enabled state, rollout percentage, or condition is changed
+ * at runtime.
  *
  * <p>Listeners can subscribe to this event via {@code @EventListener} to react to flag state
  * changes (e.g., clearing caches, logging audit trails, or updating dependent systems).
@@ -26,6 +27,9 @@ public class FeatureFlagChangedEvent extends ApplicationEvent {
   /** The new rollout percentage, or {@code null} if the rollout was not changed. */
   @Nullable private final Integer rolloutPercentage;
 
+  /** The new condition expression, or {@code null} if the condition was not changed. */
+  @Nullable private final String condition;
+
   /**
    * Constructs a {@code FeatureFlagChangedEvent} when only the enabled state changed.
    *
@@ -34,7 +38,7 @@ public class FeatureFlagChangedEvent extends ApplicationEvent {
    * @param enabled the new enabled state of the feature flag
    */
   public FeatureFlagChangedEvent(Object source, String featureName, boolean enabled) {
-    this(source, featureName, enabled, null);
+    this(source, featureName, enabled, null, null);
   }
 
   /**
@@ -48,10 +52,31 @@ public class FeatureFlagChangedEvent extends ApplicationEvent {
    */
   public FeatureFlagChangedEvent(
       Object source, String featureName, boolean enabled, @Nullable Integer rolloutPercentage) {
+    this(source, featureName, enabled, rolloutPercentage, null);
+  }
+
+  /**
+   * Constructs a {@code FeatureFlagChangedEvent} with optional rollout percentage and condition
+   * changes.
+   *
+   * @param source the object that published the event
+   * @param featureName the name of the feature flag that was changed
+   * @param enabled the new enabled state of the feature flag
+   * @param rolloutPercentage the new rollout percentage, or {@code null} if the rollout was not
+   *     changed
+   * @param condition the new condition expression, or {@code null} if the condition was not changed
+   */
+  public FeatureFlagChangedEvent(
+      Object source,
+      String featureName,
+      boolean enabled,
+      @Nullable Integer rolloutPercentage,
+      @Nullable String condition) {
     super(source);
     this.featureName = featureName;
     this.enabled = enabled;
     this.rolloutPercentage = rolloutPercentage;
+    this.condition = condition;
   }
 
   /**
@@ -80,5 +105,15 @@ public class FeatureFlagChangedEvent extends ApplicationEvent {
   @Nullable
   public Integer rolloutPercentage() {
     return rolloutPercentage;
+  }
+
+  /**
+   * Returns the new condition expression, or {@code null} if the condition was not changed.
+   *
+   * @return the SpEL condition expression, or {@code null}
+   */
+  @Nullable
+  public String condition() {
+    return condition;
   }
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureFlagProperties.java
@@ -29,7 +29,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "feature-flags")
 public class FeatureFlagProperties {
 
-  private Map<String, FeatureConfiguration> features = new HashMap<>();
+  private Map<String, FeatureProperties> features = new HashMap<>();
   private ResponseProperties response = new ResponseProperties();
   private ConditionProperties condition = new ConditionProperties();
   private boolean defaultEnabled = false;
@@ -60,6 +60,23 @@ public class FeatureFlagProperties {
   }
 
   /**
+   * Returns a map of feature names to their condition expressions. Features without a condition
+   * (empty string) are excluded.
+   *
+   * @return an immutable map of feature names to their condition expressions
+   */
+  public Map<String, String> conditions() {
+    var result = new HashMap<String, String>();
+    features.forEach(
+        (name, config) -> {
+          if (!config.condition().isEmpty()) {
+            result.put(name, config.condition());
+          }
+        });
+    return Map.copyOf(result);
+  }
+
+  /**
    * Returns a map of feature names to their schedule value objects. Features without a schedule are
    * excluded.
    *
@@ -79,9 +96,9 @@ public class FeatureFlagProperties {
   /**
    * Returns the full feature configuration map.
    *
-   * @return an immutable map of feature names to their {@link FeatureConfiguration}
+   * @return an immutable map of feature names to their {@link FeatureProperties}
    */
-  public Map<String, FeatureConfiguration> features() {
+  public Map<String, FeatureProperties> features() {
     return Map.copyOf(features);
   }
 
@@ -114,7 +131,7 @@ public class FeatureFlagProperties {
   }
 
   // for property binding
-  void setFeatures(Map<String, FeatureConfiguration> features) {
+  void setFeatures(Map<String, FeatureProperties> features) {
     this.features = features;
   }
 

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/FeatureProperties.java
@@ -1,8 +1,8 @@
 package net.brightroom.featureflag.core.properties;
 
 /**
- * Configuration for a single feature flag, including its enabled status, rollout percentage, and
- * optional schedule.
+ * Configuration for a single feature flag, including its enabled status, rollout percentage,
+ * optional condition expression, and optional schedule.
  *
  * <p>Used as the value type for {@code feature-flags.features} in {@link FeatureFlagProperties}.
  *
@@ -14,6 +14,7 @@ package net.brightroom.featureflag.core.properties;
  *     new-feature:
  *       enabled: true
  *       rollout: 50
+ *       condition: "headers['X-Beta'] != null"
  *     christmas-sale:
  *       enabled: true
  *       schedule:
@@ -24,11 +25,12 @@ package net.brightroom.featureflag.core.properties;
  *       enabled: true
  * }</pre>
  */
-public class FeatureConfiguration {
+public class FeatureProperties {
 
   private boolean enabled = true;
   private int rollout = 100;
-  private ScheduleConfiguration schedule;
+  private String condition = "";
+  private ScheduleProperties schedule;
 
   /**
    * Returns whether this feature is enabled.
@@ -52,12 +54,22 @@ public class FeatureConfiguration {
   }
 
   /**
+   * Returns the SpEL condition expression for this feature, or an empty string if no condition is
+   * configured.
+   *
+   * @return the SpEL condition expression, or empty string
+   */
+  public String condition() {
+    return condition;
+  }
+
+  /**
    * Returns the schedule configuration for this feature, or {@code null} if no schedule is
    * configured.
    *
    * @return the schedule configuration, or {@code null}
    */
-  public ScheduleConfiguration schedule() {
+  public ScheduleProperties schedule() {
     return schedule;
   }
 
@@ -75,9 +87,14 @@ public class FeatureConfiguration {
   }
 
   // for property binding
-  void setSchedule(ScheduleConfiguration schedule) {
+  void setCondition(String condition) {
+    this.condition = condition != null ? condition : "";
+  }
+
+  // for property binding
+  void setSchedule(ScheduleProperties schedule) {
     this.schedule = schedule;
   }
 
-  FeatureConfiguration() {}
+  FeatureProperties() {}
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/properties/ScheduleProperties.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/properties/ScheduleProperties.java
@@ -32,7 +32,7 @@ import net.brightroom.featureflag.core.provider.Schedule;
  *   <li>{@code timezone} omitted — system default timezone is used
  * </ul>
  */
-public class ScheduleConfiguration {
+public class ScheduleProperties {
 
   private LocalDateTime start;
   private LocalDateTime end;
@@ -101,5 +101,5 @@ public class ScheduleConfiguration {
     this.timezone = timezone;
   }
 
-  ScheduleConfiguration() {}
+  ScheduleProperties() {}
 }

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/ConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/ConditionProvider.java
@@ -1,0 +1,25 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Optional;
+
+/**
+ * SPI for resolving the SpEL condition expression for a given feature flag.
+ *
+ * <p>Implementations provide the configured condition expression for each feature flag. When a
+ * feature has no configured condition, {@link Optional#empty()} is returned and the feature is
+ * treated as having no condition restriction.
+ *
+ * <p>Implement this interface and register it as a Spring bean to override the default in-memory
+ * provider. For example, to read conditions from a database or remote config service.
+ */
+public interface ConditionProvider {
+
+  /**
+   * Returns the configured condition expression for the specified feature.
+   *
+   * @param featureName the name of the feature flag
+   * @return an {@link Optional} containing the SpEL condition expression, or {@link
+   *     Optional#empty()} if no condition is configured for this feature
+   */
+  Optional<String> getCondition(String featureName);
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryConditionProvider.java
@@ -1,0 +1,36 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link ConditionProvider} that stores condition expressions in memory using
+ * a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to resolve condition expressions.
+ * When a feature has no configured condition, {@link Optional#empty()} is returned.
+ */
+public class InMemoryConditionProvider implements ConditionProvider {
+
+  private final Map<String, String> conditions;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns {@link Optional#empty()} for features not present in the conditions map.
+   */
+  @Override
+  public Optional<String> getCondition(String featureName) {
+    return Optional.ofNullable(conditions.get(featureName));
+  }
+
+  /**
+   * Constructs an instance with the provided condition expressions.
+   *
+   * @param conditions a map containing feature flag names as keys and their condition expressions
+   *     as values; copied defensively on construction
+   */
+  public InMemoryConditionProvider(Map<String, String> conditions) {
+    this.conditions = Map.copyOf(conditions);
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryReactiveConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/InMemoryReactiveConditionProvider.java
@@ -1,0 +1,37 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * An implementation of {@link ReactiveConditionProvider} that stores condition expressions in
+ * memory using a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to resolve condition expressions
+ * reactively. When a feature has no configured condition, an empty {@link Mono} is returned.
+ */
+public class InMemoryReactiveConditionProvider implements ReactiveConditionProvider {
+
+  private final Map<String, String> conditions;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for features not present in the conditions map.
+   */
+  @Override
+  public Mono<String> getCondition(String featureName) {
+    String condition = conditions.get(featureName);
+    return condition != null ? Mono.just(condition) : Mono.empty();
+  }
+
+  /**
+   * Constructs an instance with the provided condition expressions.
+   *
+   * @param conditions a map containing feature flag names as keys and their condition expressions
+   *     as values; copied defensively on construction
+   */
+  public InMemoryReactiveConditionProvider(Map<String, String> conditions) {
+    this.conditions = Map.copyOf(conditions);
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableConditionProvider.java
@@ -1,0 +1,44 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+
+/**
+ * An extension of {@link ConditionProvider} that supports dynamic mutation of condition expressions
+ * at runtime.
+ *
+ * <p>Implementations must be thread-safe, as conditions may be read and updated concurrently.
+ *
+ * <p>This interface serves as an SPI for the actuator endpoint to update condition expressions at
+ * runtime without restarting the application.
+ */
+public interface MutableConditionProvider extends ConditionProvider {
+
+  /**
+   * Returns a snapshot of all currently configured condition expressions.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return an immutable map of feature flag names to their condition expressions
+   */
+  Map<String, String> getConditions();
+
+  /**
+   * Updates the condition expression for the specified feature flag.
+   *
+   * <p>If the feature flag does not have a configured condition, it is created.
+   *
+   * @param featureName the name of the feature flag to update
+   * @param condition the new condition expression; must not be null
+   */
+  void setCondition(String featureName, String condition);
+
+  /**
+   * Removes the condition expression for the specified feature flag.
+   *
+   * <p>If the feature flag does not have a configured condition, this method is a no-op.
+   *
+   * @param featureName the name of the feature flag whose condition to remove
+   */
+  void removeCondition(String featureName);
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryConditionProvider.java
@@ -1,0 +1,54 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableConditionProvider}.
+ *
+ * <p>Condition expressions are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and
+ * writes without external synchronization.
+ */
+public class MutableInMemoryConditionProvider implements MutableConditionProvider {
+
+  private final ConcurrentHashMap<String, String> conditions;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns {@link Optional#empty()} for features not present in the conditions map.
+   */
+  @Override
+  public Optional<String> getCondition(String featureName) {
+    return Optional.ofNullable(conditions.get(featureName));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> getConditions() {
+    return Map.copyOf(conditions);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setCondition(String featureName, String condition) {
+    conditions.put(featureName, condition);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void removeCondition(String featureName) {
+    conditions.remove(featureName);
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryConditionProvider} with the given initial condition
+   * expressions.
+   *
+   * @param conditions the initial condition expressions map; copied defensively on construction
+   */
+  public MutableInMemoryConditionProvider(Map<String, String> conditions) {
+    this.conditions = new ConcurrentHashMap<>(conditions);
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableInMemoryReactiveConditionProvider.java
@@ -1,0 +1,55 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import reactor.core.publisher.Mono;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableReactiveConditionProvider}.
+ *
+ * <p>Condition expressions are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and
+ * writes without external synchronization.
+ */
+public class MutableInMemoryReactiveConditionProvider implements MutableReactiveConditionProvider {
+
+  private final ConcurrentHashMap<String, String> conditions;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for features not present in the conditions map.
+   */
+  @Override
+  public Mono<String> getCondition(String featureName) {
+    String condition = conditions.get(featureName);
+    return condition != null ? Mono.just(condition) : Mono.empty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Map<String, String>> getConditions() {
+    return Mono.just(Map.copyOf(conditions));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Void> setCondition(String featureName, String condition) {
+    return Mono.<Void>fromRunnable(() -> conditions.put(featureName, condition));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Boolean> removeCondition(String featureName) {
+    return Mono.fromCallable(() -> conditions.remove(featureName) != null);
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryReactiveConditionProvider} with the given initial condition
+   * expressions.
+   *
+   * @param conditions the initial condition expressions map; copied defensively on construction
+   */
+  public MutableInMemoryReactiveConditionProvider(Map<String, String> conditions) {
+    this.conditions = new ConcurrentHashMap<>(conditions);
+  }
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/MutableReactiveConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/MutableReactiveConditionProvider.java
@@ -1,0 +1,50 @@
+package net.brightroom.featureflag.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * A reactive extension of {@link ReactiveConditionProvider} that supports dynamic mutation of
+ * condition expressions at runtime.
+ *
+ * <p>Implementations must be thread-safe, as conditions may be read and updated concurrently.
+ *
+ * <p>This interface serves as an SPI for the actuator endpoint to update condition expressions at
+ * runtime without restarting the application.
+ */
+public interface MutableReactiveConditionProvider extends ReactiveConditionProvider {
+
+  /**
+   * Returns a snapshot of all currently configured condition expressions.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return a {@link Mono} emitting an immutable map of feature flag names to their condition
+   *     expressions
+   */
+  Mono<Map<String, String>> getConditions();
+
+  /**
+   * Updates the condition expression for the specified feature flag.
+   *
+   * <p>If the feature flag does not have a configured condition, it is created.
+   *
+   * @param featureName the name of the feature flag to update
+   * @param condition the new condition expression; must not be null
+   * @return a {@link Mono} that completes when the update is applied
+   */
+  Mono<Void> setCondition(String featureName, String condition);
+
+  /**
+   * Removes the condition expression for the specified feature flag.
+   *
+   * <p>If the feature flag does not have a configured condition, this method is a no-op and emits
+   * {@code false}.
+   *
+   * @param featureName the name of the feature flag whose condition to remove
+   * @return a {@link Mono} emitting {@code true} if the condition existed and was removed, {@code
+   *     false} if it did not exist
+   */
+  Mono<Boolean> removeCondition(String featureName);
+}

--- a/core/src/main/java/net/brightroom/featureflag/core/provider/ReactiveConditionProvider.java
+++ b/core/src/main/java/net/brightroom/featureflag/core/provider/ReactiveConditionProvider.java
@@ -1,0 +1,25 @@
+package net.brightroom.featureflag.core.provider;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for resolving the SpEL condition expression for a given feature flag.
+ *
+ * <p>Implementations provide the configured condition expression for each feature flag. When a
+ * feature has no configured condition, an empty {@link Mono} is returned and the feature is treated
+ * as having no condition restriction.
+ *
+ * <p>Implement this interface and register it as a Spring bean to override the default in-memory
+ * provider. For example, to read conditions from a reactive data source.
+ */
+public interface ReactiveConditionProvider {
+
+  /**
+   * Returns the configured condition expression for the specified feature.
+   *
+   * @param featureName the name of the feature flag
+   * @return a {@link Mono} emitting the SpEL condition expression, or an empty {@link Mono} if no
+   *     condition is configured for this feature
+   */
+  Mono<String> getCondition(String featureName);
+}

--- a/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "feature-flags.features",
-      "type": "java.util.Map<java.lang.String,net.brightroom.featureflag.core.properties.FeatureConfiguration>",
+      "type": "java.util.Map<java.lang.String,net.brightroom.featureflag.core.properties.FeatureProperties>",
       "description": "Per-feature configuration including enabled state and rollout percentage."
     },
     {
@@ -34,6 +34,11 @@
       "type": "java.lang.Integer",
       "description": "Rollout percentage for this feature flag (0-100). 100 means fully rolled out to all requests; 0 means no requests even if enabled.",
       "defaultValue": 100
+    },
+    {
+      "name": "feature-flags.features.[*].condition",
+      "type": "java.lang.String",
+      "description": "SpEL expression evaluated against the request context to conditionally enable this feature. Available variables: headers, params, cookies, path, method, remoteAddress. If empty, no condition is applied."
     },
     {
       "name": "feature-flags.response.type",

--- a/core/src/test/java/net/brightroom/featureflag/core/properties/FeatureFlagPropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/properties/FeatureFlagPropertiesTest.java
@@ -13,6 +13,58 @@ class FeatureFlagPropertiesTest {
     return new FeatureFlagProperties();
   }
 
+  // --- conditions() ---
+
+  @Test
+  void conditions_returnsEmptyMap_whenNoFeaturesConfigured() {
+    FeatureFlagProperties properties = newProperties();
+
+    assertTrue(properties.conditions().isEmpty());
+  }
+
+  @Test
+  void conditions_excludesFeatures_whenConditionIsEmpty() {
+    FeatureFlagProperties properties = newProperties();
+    FeatureProperties config = new FeatureProperties();
+    // no condition set → condition() returns ""
+    properties.setFeatures(Map.of("no-condition-feature", config));
+
+    assertTrue(properties.conditions().isEmpty());
+  }
+
+  @Test
+  void conditions_includesFeature_whenConditionIsConfigured() {
+    FeatureFlagProperties properties = newProperties();
+    FeatureProperties config = new FeatureProperties();
+    config.setCondition("headers['X-Beta'] != null");
+    properties.setFeatures(Map.of("conditional-feature", config));
+
+    var conditions = properties.conditions();
+    assertEquals(1, conditions.size());
+    assertEquals("headers['X-Beta'] != null", conditions.get("conditional-feature"));
+  }
+
+  @Test
+  void conditions_mapsMultipleFeatures_whenMultipleConditionsConfigured() {
+    FeatureFlagProperties properties = newProperties();
+
+    FeatureProperties config1 = new FeatureProperties();
+    config1.setCondition("headers['X-Beta'] != null");
+
+    FeatureProperties config2 = new FeatureProperties();
+    config2.setCondition("params['variant'] == 'B'");
+
+    FeatureProperties configNoCondition = new FeatureProperties();
+
+    properties.setFeatures(
+        Map.of("feature-a", config1, "feature-b", config2, "feature-c", configNoCondition));
+
+    var conditions = properties.conditions();
+    assertEquals(2, conditions.size());
+    assertEquals("headers['X-Beta'] != null", conditions.get("feature-a"));
+    assertEquals("params['variant'] == 'B'", conditions.get("feature-b"));
+  }
+
   // --- schedules() ---
 
   @Test
@@ -25,7 +77,7 @@ class FeatureFlagPropertiesTest {
   @Test
   void schedules_excludesFeatures_whenScheduleIsNull() {
     FeatureFlagProperties properties = newProperties();
-    FeatureConfiguration config = new FeatureConfiguration();
+    FeatureProperties config = new FeatureProperties();
     // no schedule set → schedule() returns null
     properties.setFeatures(Map.of("no-schedule-feature", config));
 
@@ -35,11 +87,11 @@ class FeatureFlagPropertiesTest {
   @Test
   void schedules_includesFeature_whenScheduleIsConfigured() {
     FeatureFlagProperties properties = newProperties();
-    ScheduleConfiguration scheduleConfig = new ScheduleConfiguration();
+    ScheduleProperties scheduleConfig = new ScheduleProperties();
     scheduleConfig.setStart(LocalDateTime.of(2026, 6, 15, 10, 0));
     scheduleConfig.setEnd(LocalDateTime.of(2026, 6, 15, 18, 0));
 
-    FeatureConfiguration config = new FeatureConfiguration();
+    FeatureProperties config = new FeatureProperties();
     config.setSchedule(scheduleConfig);
     properties.setFeatures(Map.of("scheduled-feature", config));
 
@@ -53,17 +105,17 @@ class FeatureFlagPropertiesTest {
   void schedules_mapsMultipleFeatures_whenMultipleSchedulesConfigured() {
     FeatureFlagProperties properties = newProperties();
 
-    ScheduleConfiguration schedule1 = new ScheduleConfiguration();
+    ScheduleProperties schedule1 = new ScheduleProperties();
     schedule1.setStart(LocalDateTime.of(2026, 1, 1, 0, 0));
-    FeatureConfiguration config1 = new FeatureConfiguration();
+    FeatureProperties config1 = new FeatureProperties();
     config1.setSchedule(schedule1);
 
-    ScheduleConfiguration schedule2 = new ScheduleConfiguration();
+    ScheduleProperties schedule2 = new ScheduleProperties();
     schedule2.setEnd(LocalDateTime.of(2026, 12, 31, 23, 59));
-    FeatureConfiguration config2 = new FeatureConfiguration();
+    FeatureProperties config2 = new FeatureProperties();
     config2.setSchedule(schedule2);
 
-    FeatureConfiguration configNoSchedule = new FeatureConfiguration();
+    FeatureProperties configNoSchedule = new FeatureProperties();
 
     properties.setFeatures(
         Map.of("feature-a", config1, "feature-b", config2, "feature-c", configNoSchedule));

--- a/core/src/test/java/net/brightroom/featureflag/core/properties/FeaturePropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/properties/FeaturePropertiesTest.java
@@ -6,12 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class FeatureConfigurationTest {
+class FeaturePropertiesTest {
 
   @ParameterizedTest
   @ValueSource(ints = {0, 1, 50, 99, 100})
   void setRollout_shouldAcceptValidValues(int rollout) {
-    FeatureConfiguration config = new FeatureConfiguration();
+    FeatureProperties config = new FeatureProperties();
     assertDoesNotThrow(() -> config.setRollout(rollout));
     assertEquals(rollout, config.rollout());
   }
@@ -19,7 +19,7 @@ class FeatureConfigurationTest {
   @ParameterizedTest
   @ValueSource(ints = {-1, -100, 101, 200})
   void setRollout_shouldRejectOutOfRangeValues(int rollout) {
-    FeatureConfiguration config = new FeatureConfiguration();
+    FeatureProperties config = new FeatureProperties();
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> config.setRollout(rollout));
     assertTrue(ex.getMessage().contains(String.valueOf(rollout)));
@@ -27,7 +27,7 @@ class FeatureConfigurationTest {
 
   @Test
   void setRollout_errorMessageShouldContainInvalidValue() {
-    FeatureConfiguration config = new FeatureConfiguration();
+    FeatureProperties config = new FeatureProperties();
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> config.setRollout(101));
     assertEquals("rollout must be between 0 and 100, but was: 101", ex.getMessage());

--- a/core/src/test/java/net/brightroom/featureflag/core/properties/SchedulePropertiesTest.java
+++ b/core/src/test/java/net/brightroom/featureflag/core/properties/SchedulePropertiesTest.java
@@ -8,17 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
-class ScheduleConfigurationTest {
+class SchedulePropertiesTest {
 
-  private ScheduleConfiguration newSchedule() {
-    return new ScheduleConfiguration();
+  private ScheduleProperties newSchedule() {
+    return new ScheduleProperties();
   }
 
   // --- setEnd() validation ---
 
   @Test
   void setEnd_throwsIllegalArgumentException_whenEndIsBeforeStart() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatIllegalArgumentException()
@@ -28,7 +28,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void setEnd_doesNotThrow_whenEndEqualsStart() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0)));
@@ -36,7 +36,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void setEnd_doesNotThrow_whenEndIsAfterStart() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 13, 0)));
@@ -44,14 +44,14 @@ class ScheduleConfigurationTest {
 
   @Test
   void setEnd_doesNotThrow_whenStartIsNull() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
 
     assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 11, 0)));
   }
 
   @Test
   void setEnd_doesNotThrow_whenEndIsNull() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatNoException().isThrownBy(() -> schedule.setEnd(null));
@@ -61,7 +61,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void setStart_throwsIllegalArgumentException_whenStartIsAfterEnd() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatIllegalArgumentException()
@@ -71,7 +71,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void setStart_doesNotThrow_whenStartEqualsEnd() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatNoException()
@@ -80,7 +80,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void setStart_doesNotThrow_whenStartIsBeforeEnd() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatNoException()
@@ -89,7 +89,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void setStart_doesNotThrow_whenEndIsNull() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
 
     assertThatNoException()
         .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0)));
@@ -97,7 +97,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void setStart_doesNotThrow_whenStartIsNull() {
-    ScheduleConfiguration schedule = newSchedule();
+    ScheduleProperties schedule = newSchedule();
     schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
 
     assertThatNoException().isThrownBy(() -> schedule.setStart(null));
@@ -107,7 +107,7 @@ class ScheduleConfigurationTest {
 
   @Test
   void toSchedule_returnsScheduleWithSameValues() {
-    ScheduleConfiguration config = newSchedule();
+    ScheduleProperties config = newSchedule();
     config.setStart(LocalDateTime.of(2026, 6, 15, 10, 0));
     config.setEnd(LocalDateTime.of(2026, 6, 15, 18, 0));
 

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectConditionIntegrationTest.java
@@ -13,8 +13,15 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @Import(FeatureFlagWebFluxTestAutoConfiguration.class)
 @TestPropertySource(
     properties = {
-      "feature-flags.features.conditional-feature.enabled=true",
-      "feature-flags.features.conditional-feature.rollout=100",
+      "feature-flags.features.header-condition-feature.enabled=true",
+      "feature-flags.features.header-condition-feature.condition=headers['X-Beta'] != null",
+      "feature-flags.features.param-condition-feature.enabled=true",
+      "feature-flags.features.param-condition-feature.condition=params['variant'] == 'B'",
+      "feature-flags.features.condition-rollout-feature.enabled=true",
+      "feature-flags.features.condition-rollout-feature.condition=headers['X-Beta'] != null",
+      "feature-flags.features.condition-rollout-feature.rollout=100",
+      "feature-flags.features.remote-address-condition-feature.enabled=true",
+      "feature-flags.features.remote-address-condition-feature.condition=remoteAddress == '127.0.0.1'",
     })
 class FeatureFlagAspectConditionIntegrationTest {
 
@@ -45,7 +52,7 @@ class FeatureFlagAspectConditionIntegrationTest {
         .json(
             """
             {
-              "detail" : "Feature 'conditional-feature' is not available",
+              "detail" : "Feature 'header-condition-feature' is not available",
               "instance" : "/condition/header",
               "status" : 403,
               "title" : "Feature flag access denied",

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectRolloutIntegrationTest.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/FeatureFlagAspectRolloutIntegrationTest.java
@@ -29,7 +29,10 @@ import reactor.core.publisher.Mono;
  */
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
-    properties = {"feature-flags.features.rollout-feature.enabled=true"})
+    properties = {
+      "feature-flags.features.rollout-feature.enabled=true",
+      "feature-flags.features.rollout-feature.rollout=50"
+    })
 class FeatureFlagAspectRolloutIntegrationTest {
 
   private static final FeatureFlagContext FIXED_CONTEXT = new FeatureFlagContext("fixed-user-id");

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagClassRolloutController.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagClassRolloutController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 @RestController
-@FeatureFlag(value = "rollout-feature", rollout = 50)
+@FeatureFlag("rollout-feature")
 public class FeatureFlagClassRolloutController {
 
   @GetMapping("/test/class-rollout")

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagConditionController.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagConditionController.java
@@ -8,25 +8,25 @@ import reactor.core.publisher.Mono;
 @RestController
 public class FeatureFlagConditionController {
 
-  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null")
+  @FeatureFlag("header-condition-feature")
   @GetMapping("/condition/header")
   Mono<String> headerCondition() {
     return Mono.just("Allowed");
   }
 
-  @FeatureFlag(value = "conditional-feature", condition = "params['variant'] == 'B'")
+  @FeatureFlag("param-condition-feature")
   @GetMapping("/condition/param")
   Mono<String> paramCondition() {
     return Mono.just("Allowed");
   }
 
-  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null", rollout = 50)
+  @FeatureFlag("condition-rollout-feature")
   @GetMapping("/condition/with-rollout")
   Mono<String> conditionWithRollout() {
     return Mono.just("Allowed");
   }
 
-  @FeatureFlag(value = "conditional-feature", condition = "remoteAddress == '127.0.0.1'")
+  @FeatureFlag("remote-address-condition-feature")
   @GetMapping("/condition/remote-address")
   Mono<String> remoteAddressCondition() {
     return Mono.just("Allowed");

--- a/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagRolloutController.java
+++ b/webflux/src/integrationTest/java/net/brightroom/featureflag/webflux/endpoint/FeatureFlagRolloutController.java
@@ -9,7 +9,7 @@ import reactor.core.publisher.Mono;
 public class FeatureFlagRolloutController {
 
   @GetMapping("/test/rollout")
-  @FeatureFlag(value = "rollout-feature", rollout = 50)
+  @FeatureFlag("rollout-feature")
   public Mono<String> testRollout() {
     return Mono.just("Allowed");
   }

--- a/webflux/src/integrationTest/resources/application.yaml
+++ b/webflux/src/integrationTest/resources/application.yaml
@@ -10,5 +10,8 @@ feature-flags:
       enabled: false
     conditional-feature:
       enabled: true
+    remote-address-condition-feature:
+      enabled: true
+      condition: "remoteAddress == '127.0.0.1'"
   response:
     type: json

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspect.java
@@ -6,6 +6,7 @@ import net.brightroom.featureflag.core.evaluation.AccessDecision;
 import net.brightroom.featureflag.core.evaluation.EvaluationContext;
 import net.brightroom.featureflag.core.evaluation.ReactiveFeatureFlagEvaluationPipeline;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.webflux.condition.ServerHttpConditionVariables;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
@@ -38,6 +39,7 @@ public class FeatureFlagAspect {
   private final ReactiveFeatureFlagEvaluationPipeline pipeline;
   private final ReactiveFeatureFlagContextResolver contextResolver;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
+  private final ReactiveConditionProvider conditionProvider;
 
   /**
    * Around advice that checks the feature flag before proceeding with the annotated method.
@@ -45,7 +47,7 @@ public class FeatureFlagAspect {
    * <p>Applies to methods and classes annotated with {@link
    * net.brightroom.featureflag.core.annotation.FeatureFlag}. If the feature is disabled, a {@link
    * net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException} is returned in the
-   * reactive pipeline. Rollout percentage is also evaluated when configured.
+   * reactive pipeline. Rollout percentage and condition are also evaluated when configured.
    *
    * @param joinPoint the proceeding join point of the intercepted method
    * @return the result of the intercepted method, or an error signal if access is denied
@@ -63,8 +65,6 @@ public class FeatureFlagAspect {
     validateAnnotation(annotation);
 
     String featureName = annotation.value();
-    String condition = annotation.condition();
-    int annotationRollout = annotation.rollout();
 
     Class<?> returnType = ((MethodSignature) joinPoint.getSignature()).getReturnType();
 
@@ -73,9 +73,10 @@ public class FeatureFlagAspect {
             ctx -> {
               ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
               return Mono.zip(
+                      conditionProvider.getCondition(featureName).defaultIfEmpty(""),
                       rolloutPercentageProvider
                           .getRolloutPercentage(featureName)
-                          .defaultIfEmpty(annotationRollout),
+                          .defaultIfEmpty(100),
                       contextResolver
                           .resolve(exchange.getRequest())
                           .map(java.util.Optional::of)
@@ -85,10 +86,10 @@ public class FeatureFlagAspect {
                         EvaluationContext evalCtx =
                             new EvaluationContext(
                                 featureName,
-                                condition,
                                 tuple.getT1(),
+                                tuple.getT2(),
                                 ServerHttpConditionVariables.build(exchange.getRequest()),
-                                () -> tuple.getT2().orElse(null));
+                                () -> tuple.getT3().orElse(null));
                         return pipeline.evaluate(evalCtx);
                       });
             });
@@ -156,10 +157,6 @@ public class FeatureFlagAspect {
           "@FeatureFlag must specify a non-empty value. "
               + "An empty value causes fail-open behavior and allows access unconditionally.");
     }
-    if (annotation.rollout() < 0 || annotation.rollout() > 100) {
-      throw new IllegalStateException(
-          "@FeatureFlag rollout must be between 0 and 100, but was: " + annotation.rollout());
-    }
   }
 
   /**
@@ -171,13 +168,17 @@ public class FeatureFlagAspect {
    *     be null
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature; must not be null
+   * @param conditionProvider the provider used to look up the condition expression per feature;
+   *     must not be null
    */
   public FeatureFlagAspect(
       ReactiveFeatureFlagEvaluationPipeline pipeline,
       ReactiveFeatureFlagContextResolver contextResolver,
-      ReactiveRolloutPercentageProvider rolloutPercentageProvider) {
+      ReactiveRolloutPercentageProvider rolloutPercentageProvider,
+      ReactiveConditionProvider conditionProvider) {
     this.pipeline = pipeline;
     this.contextResolver = contextResolver;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionProvider = conditionProvider;
   }
 }

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/autoconfigure/FeatureFlagWebFluxAutoConfiguration.java
@@ -14,8 +14,10 @@ import net.brightroom.featureflag.core.evaluation.ReactiveFeatureFlagEvaluationP
 import net.brightroom.featureflag.core.evaluation.ReactiveRolloutEvaluationStep;
 import net.brightroom.featureflag.core.evaluation.ReactiveScheduleEvaluationStep;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
+import net.brightroom.featureflag.core.provider.InMemoryReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.InMemoryReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.InMemoryReactiveScheduleProvider;
+import net.brightroom.featureflag.core.provider.ReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
@@ -101,6 +103,12 @@ public class FeatureFlagWebFluxAutoConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean(ReactiveConditionProvider.class)
+  ReactiveConditionProvider reactiveConditionProvider() {
+    return new InMemoryReactiveConditionProvider(featureFlagProperties.conditions());
+  }
+
+  @Bean
   @ConditionalOnMissingBean
   Clock featureFlagClock() {
     return Clock.systemDefaultZone();
@@ -180,8 +188,10 @@ public class FeatureFlagWebFluxAutoConfiguration {
   FeatureFlagAspect featureFlagAspect(
       ReactiveFeatureFlagEvaluationPipeline pipeline,
       ReactiveFeatureFlagContextResolver contextResolver,
-      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider) {
-    return new FeatureFlagAspect(pipeline, contextResolver, reactiveRolloutPercentageProvider);
+      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
+      ReactiveConditionProvider reactiveConditionProvider) {
+    return new FeatureFlagAspect(
+        pipeline, contextResolver, reactiveRolloutPercentageProvider, reactiveConditionProvider);
   }
 
   @Bean
@@ -196,11 +206,13 @@ public class FeatureFlagWebFluxAutoConfiguration {
       ReactiveFeatureFlagEvaluationPipeline pipeline,
       AccessDeniedHandlerFilterResolution accessDeniedHandlerResolution,
       ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
+      ReactiveConditionProvider reactiveConditionProvider,
       ReactiveFeatureFlagContextResolver contextResolver) {
     return new FeatureFlagHandlerFilterFunction(
         pipeline,
         accessDeniedHandlerResolution,
         reactiveRolloutPercentageProvider,
+        reactiveConditionProvider,
         contextResolver);
   }
 

--- a/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webflux/src/main/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunction.java
@@ -4,6 +4,7 @@ import net.brightroom.featureflag.core.evaluation.AccessDecision;
 import net.brightroom.featureflag.core.evaluation.EvaluationContext;
 import net.brightroom.featureflag.core.evaluation.ReactiveFeatureFlagEvaluationPipeline;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.webflux.condition.ServerHttpConditionVariables;
 import net.brightroom.featureflag.webflux.context.ReactiveFeatureFlagContextResolver;
@@ -34,17 +35,21 @@ import reactor.core.publisher.Mono;
  * The default response format follows {@code feature-flags.response.type} configuration, and can be
  * customized by providing a custom {@link AccessDeniedHandlerFilterResolution} bean.
  *
- * <p>Use {@link #of(String, int)} to enable gradual rollout for functional endpoints.
+ * <p>Use {@link #of(String, int)} to enable gradual rollout for functional endpoints with a
+ * fallback rollout percentage.
  */
 public class FeatureFlagHandlerFilterFunction {
 
   private final ReactiveFeatureFlagEvaluationPipeline pipeline;
   private final AccessDeniedHandlerFilterResolution resolution;
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
+  private final ReactiveConditionProvider conditionProvider;
   private final ReactiveFeatureFlagContextResolver contextResolver;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
+   *
+   * <p>Condition and rollout percentage are resolved from the configured providers.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
@@ -56,23 +61,29 @@ public class FeatureFlagHandlerFilterFunction {
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
-   * and SpEL condition expression.
+   * and fallback condition expression.
+   *
+   * <p>The condition is resolved from the provider first; the {@code conditionFallback} is used
+   * only when the provider returns no value for the feature.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
-   * @param condition SpEL expression evaluated against request context; empty string means no
-   *     condition
+   * @param conditionFallback SpEL expression used as fallback when the provider has no condition
+   *     configured; empty string means no condition
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
    *     and condition
    * @throws IllegalArgumentException if {@code featureName} is null or blank
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
-      String featureName, String condition) {
-    return of(featureName, condition, 100);
+      String featureName, String conditionFallback) {
+    return of(featureName, conditionFallback, 100);
   }
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
-   * and rollout percentage.
+   * and fallback rollout percentage.
+   *
+   * <p>The rollout percentage is resolved from the provider first; the {@code rolloutFallback} is
+   * used only when the provider returns no value for the feature.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
@@ -89,14 +100,17 @@ public class FeatureFlagHandlerFilterFunction {
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag,
-   * SpEL condition expression, and rollout percentage.
+   * fallback SpEL condition expression, and fallback rollout percentage.
+   *
+   * <p>The condition and rollout percentage are resolved from their respective providers first;
+   * fallback values are used only when the providers return no value for the feature.
    *
    * <p>The evaluation order is: feature enabled check → schedule check → condition check → rollout
    * check.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
-   * @param condition SpEL expression evaluated against request context; empty string means no
-   *     condition
+   * @param conditionFallback SpEL expression used as fallback when the provider has no condition
+   *     configured; empty string means no condition
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
    *     the provider; 100 means fully enabled
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag,
@@ -105,7 +119,7 @@ public class FeatureFlagHandlerFilterFunction {
    *     rolloutFallback} is not between 0 and 100
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
-      String featureName, String condition, int rolloutFallback) {
+      String featureName, String conditionFallback, int rolloutFallback) {
     if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException(
           "featureName must not be null or blank. "
@@ -117,6 +131,7 @@ public class FeatureFlagHandlerFilterFunction {
     }
     return (request, next) ->
         Mono.zip(
+                conditionProvider.getCondition(featureName).defaultIfEmpty(conditionFallback),
                 rolloutPercentageProvider
                     .getRolloutPercentage(featureName)
                     .defaultIfEmpty(rolloutFallback),
@@ -129,10 +144,10 @@ public class FeatureFlagHandlerFilterFunction {
                   EvaluationContext evalCtx =
                       new EvaluationContext(
                           featureName,
-                          condition,
                           tuple.getT1(),
+                          tuple.getT2(),
                           ServerHttpConditionVariables.build(request.exchange().getRequest()),
-                          () -> tuple.getT2().orElse(null));
+                          () -> tuple.getT3().orElse(null));
                   return pipeline.evaluate(evalCtx);
                 })
             .flatMap(
@@ -154,6 +169,8 @@ public class FeatureFlagHandlerFilterFunction {
    *     must not be null
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature; must not be null
+   * @param conditionProvider the provider used to look up the condition expression per feature;
+   *     must not be null
    * @param contextResolver the resolver used to extract context from the current request; must not
    *     be null
    */
@@ -161,10 +178,12 @@ public class FeatureFlagHandlerFilterFunction {
       ReactiveFeatureFlagEvaluationPipeline pipeline,
       AccessDeniedHandlerFilterResolution resolution,
       ReactiveRolloutPercentageProvider rolloutPercentageProvider,
+      ReactiveConditionProvider conditionProvider,
       ReactiveFeatureFlagContextResolver contextResolver) {
     this.pipeline = pipeline;
     this.resolution = resolution;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionProvider = conditionProvider;
     this.contextResolver = contextResolver;
   }
 }

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/aspect/FeatureFlagAspectTest.java
@@ -20,6 +20,7 @@ import net.brightroom.featureflag.core.evaluation.ReactiveFeatureFlagEvaluationP
 import net.brightroom.featureflag.core.evaluation.ReactiveRolloutEvaluationStep;
 import net.brightroom.featureflag.core.evaluation.ReactiveScheduleEvaluationStep;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
@@ -46,6 +47,8 @@ class FeatureFlagAspectTest {
       mock(ReactiveFeatureFlagContextResolver.class, invocation -> Mono.empty());
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
       mock(ReactiveRolloutPercentageProvider.class, invocation -> Mono.empty());
+  private final ReactiveConditionProvider conditionProvider =
+      mock(ReactiveConditionProvider.class, invocation -> Mono.empty());
   private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator =
       mock(ReactiveFeatureFlagConditionEvaluator.class);
   private final ReactiveScheduleProvider reactiveScheduleProvider =
@@ -66,11 +69,15 @@ class FeatureFlagAspectTest {
       new FeatureFlagAspect(
           buildPipeline(new DefaultReactiveRolloutStrategy()),
           contextResolver,
-          rolloutPercentageProvider);
+          rolloutPercentageProvider,
+          conditionProvider);
 
   private final FeatureFlagAspect aspectWithRollout =
       new FeatureFlagAspect(
-          buildPipeline(rolloutStrategy), contextResolver, rolloutPercentageProvider);
+          buildPipeline(rolloutStrategy),
+          contextResolver,
+          rolloutPercentageProvider,
+          conditionProvider);
 
   // Helper: creates a mock exchange with a mocked request
   private ServerWebExchange mockExchange() {
@@ -103,34 +110,24 @@ class FeatureFlagAspectTest {
       return Flux.just("result1", "result2");
     }
 
-    @FeatureFlag(value = "some-feature", rollout = 50)
+    @FeatureFlag("some-feature")
     public Mono<String> rolloutMonoMethod() {
       return Mono.just("result");
     }
 
-    @FeatureFlag(value = "some-feature", rollout = 50)
+    @FeatureFlag("some-feature")
     public Flux<String> rolloutFluxMethod() {
       return Flux.just("result1", "result2");
     }
 
-    @FeatureFlag(value = "some-feature", condition = "headers['X-Beta'] != null")
+    @FeatureFlag("some-feature")
     public Mono<String> conditionMonoMethod() {
       return Mono.just("result");
     }
 
-    @FeatureFlag(value = "some-feature", condition = "headers['X-Beta'] != null")
+    @FeatureFlag("some-feature")
     public Flux<String> conditionFluxMethod() {
       return Flux.just("result1", "result2");
-    }
-
-    @FeatureFlag(value = "some-feature", rollout = -1)
-    public Mono<String> negativeRolloutMethod() {
-      return Mono.just("result");
-    }
-
-    @FeatureFlag(value = "some-feature", rollout = 101)
-    public Mono<String> over100RolloutMethod() {
-      return Mono.just("result");
     }
   }
 
@@ -263,36 +260,6 @@ class FeatureFlagAspectTest {
   }
 
   @Test
-  void checkFeatureFlag_throwsIllegalStateException_whenRolloutIsNegative() throws Throwable {
-    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
-    MethodSignature signature = mock(MethodSignature.class);
-    when(joinPoint.getSignature()).thenReturn(signature);
-
-    Method method = TestController.class.getMethod("negativeRolloutMethod");
-    when(signature.getMethod()).thenReturn(method);
-    when(joinPoint.getTarget()).thenReturn(new TestController());
-
-    assertThatThrownBy(() -> aspect.checkFeatureFlag(joinPoint))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("rollout must be between 0 and 100");
-  }
-
-  @Test
-  void checkFeatureFlag_throwsIllegalStateException_whenRolloutIsOver100() throws Throwable {
-    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
-    MethodSignature signature = mock(MethodSignature.class);
-    when(joinPoint.getSignature()).thenReturn(signature);
-
-    Method method = TestController.class.getMethod("over100RolloutMethod");
-    when(signature.getMethod()).thenReturn(method);
-    when(joinPoint.getTarget()).thenReturn(new TestController());
-
-    assertThatThrownBy(() -> aspect.checkFeatureFlag(joinPoint))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("rollout must be between 0 and 100");
-  }
-
-  @Test
   void checkFeatureFlag_throwsIllegalStateException_whenReturnTypeIsNonReactive() throws Throwable {
     ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
     MethodSignature signature = mock(MethodSignature.class);
@@ -383,6 +350,7 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Mono.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
 
     ServerWebExchange exchange = mock(ServerWebExchange.class);
     ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
@@ -415,6 +383,7 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Mono.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
     when(joinPoint.proceed()).thenReturn(Mono.just("result"));
 
     ServerWebExchange exchange = mock(ServerWebExchange.class);
@@ -446,6 +415,7 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Mono.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
     when(joinPoint.proceed()).thenReturn(Mono.just("result"));
 
     ServerWebExchange exchange = mock(ServerWebExchange.class);
@@ -474,6 +444,7 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Flux.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
 
     ServerWebExchange exchange = mock(ServerWebExchange.class);
     ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
@@ -506,6 +477,7 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Flux.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
     when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
 
     ServerWebExchange exchange = mock(ServerWebExchange.class);
@@ -537,6 +509,7 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Flux.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
     when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
 
     ServerWebExchange exchange = mock(ServerWebExchange.class);
@@ -649,6 +622,8 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Mono.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
     when(joinPoint.proceed()).thenReturn(Mono.just("result"));
     when(conditionEvaluator.evaluate(
             org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
@@ -680,6 +655,8 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Mono.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
     when(conditionEvaluator.evaluate(
             org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
             org.mockito.ArgumentMatchers.any()))
@@ -712,6 +689,8 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Flux.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
     when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
     when(conditionEvaluator.evaluate(
             org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
@@ -743,6 +722,8 @@ class FeatureFlagAspectTest {
     when(signature.getReturnType()).thenReturn(Flux.class);
     when(joinPoint.getTarget()).thenReturn(new TestController());
     when(provider.isFeatureEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
     when(conditionEvaluator.evaluate(
             org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
             org.mockito.ArgumentMatchers.any()))

--- a/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webflux/src/test/java/net/brightroom/featureflag/webflux/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -19,6 +19,7 @@ import net.brightroom.featureflag.core.evaluation.ReactiveFeatureFlagEvaluationP
 import net.brightroom.featureflag.core.evaluation.ReactiveRolloutEvaluationStep;
 import net.brightroom.featureflag.core.evaluation.ReactiveScheduleEvaluationStep;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ReactiveConditionProvider;
 import net.brightroom.featureflag.core.provider.ReactiveFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.ReactiveRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.ReactiveScheduleProvider;
@@ -49,6 +50,8 @@ class FeatureFlagHandlerFilterFunctionTest {
       mock(ReactiveFeatureFlagContextResolver.class, invocation -> Mono.empty());
   private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
       mock(ReactiveRolloutPercentageProvider.class, invocation -> Mono.empty());
+  private final ReactiveConditionProvider conditionProvider =
+      mock(ReactiveConditionProvider.class, invocation -> Mono.empty());
   private final ReactiveFeatureFlagConditionEvaluator conditionEvaluator =
       mock(ReactiveFeatureFlagConditionEvaluator.class);
   private final ReactiveScheduleProvider reactiveScheduleProvider =
@@ -69,11 +72,16 @@ class FeatureFlagHandlerFilterFunctionTest {
           buildPipeline(new DefaultReactiveRolloutStrategy()),
           resolution,
           rolloutPercentageProvider,
+          conditionProvider,
           contextResolver);
 
   private final FeatureFlagHandlerFilterFunction filterFunctionWithRollout =
       new FeatureFlagHandlerFilterFunction(
-          buildPipeline(rolloutStrategy), resolution, rolloutPercentageProvider, contextResolver);
+          buildPipeline(rolloutStrategy),
+          resolution,
+          rolloutPercentageProvider,
+          conditionProvider,
+          contextResolver);
 
   private ServerRequest mockRequest() {
     ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorConditionIntegrationTest.java
@@ -17,8 +17,15 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import(FeatureFlagMvcTestAutoConfiguration.class)
 @TestPropertySource(
     properties = {
-      "feature-flags.features.conditional-feature.enabled=true",
-      "feature-flags.features.conditional-feature.rollout=100",
+      "feature-flags.features.header-condition-feature.enabled=true",
+      "feature-flags.features.header-condition-feature.condition=headers['X-Beta'] != null",
+      "feature-flags.features.param-condition-feature.enabled=true",
+      "feature-flags.features.param-condition-feature.condition=params['variant'] == 'B'",
+      "feature-flags.features.condition-rollout-feature.enabled=true",
+      "feature-flags.features.condition-rollout-feature.condition=headers['X-Beta'] != null",
+      "feature-flags.features.condition-rollout-feature.rollout=100",
+      "feature-flags.features.remote-address-condition-feature.enabled=true",
+      "feature-flags.features.remote-address-condition-feature.condition=remoteAddress == '127.0.0.1'",
     })
 class FeatureFlagInterceptorConditionIntegrationTest {
 
@@ -42,7 +49,7 @@ class FeatureFlagInterceptorConditionIntegrationTest {
                 .json(
                     """
                   {
-                    "detail" : "Feature 'conditional-feature' is not available",
+                    "detail" : "Feature 'header-condition-feature' is not available",
                     "instance" : "/condition/header",
                     "status" : 403,
                     "title" : "Feature flag access denied",

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorRolloutIntegrationTest.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/FeatureFlagInterceptorRolloutIntegrationTest.java
@@ -33,7 +33,10 @@ import org.springframework.test.web.servlet.ResultMatcher;
  * </ul>
  */
 @WebMvcTest(
-    properties = {"feature-flags.features.rollout-feature.enabled=true"},
+    properties = {
+      "feature-flags.features.rollout-feature.enabled=true",
+      "feature-flags.features.rollout-feature.rollout=50"
+    },
     controllers = {FeatureFlagRolloutController.class, FeatureFlagClassRolloutController.class})
 @Import({
   FeatureFlagMvcTestAutoConfiguration.class,

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagClassRolloutController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagClassRolloutController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@FeatureFlag(value = "rollout-feature", rollout = 50)
+@FeatureFlag("rollout-feature")
 public class FeatureFlagClassRolloutController {
 
   @GetMapping("/test/class-rollout")

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagConditionController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagConditionController.java
@@ -7,25 +7,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class FeatureFlagConditionController {
 
-  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null")
+  @FeatureFlag("header-condition-feature")
   @GetMapping("/condition/header")
   String headerCondition() {
     return "Allowed";
   }
 
-  @FeatureFlag(value = "conditional-feature", condition = "params['variant'] == 'B'")
+  @FeatureFlag("param-condition-feature")
   @GetMapping("/condition/param")
   String paramCondition() {
     return "Allowed";
   }
 
-  @FeatureFlag(value = "conditional-feature", condition = "headers['X-Beta'] != null", rollout = 50)
+  @FeatureFlag("condition-rollout-feature")
   @GetMapping("/condition/with-rollout")
   String conditionWithRollout() {
     return "Allowed";
   }
 
-  @FeatureFlag(value = "conditional-feature", condition = "remoteAddress == '127.0.0.1'")
+  @FeatureFlag("remote-address-condition-feature")
   @GetMapping("/condition/remote-address")
   String remoteAddressCondition() {
     return "Allowed";

--- a/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagRolloutController.java
+++ b/webmvc/src/integrationTest/java/net/brightroom/featureflag/webmvc/endpoint/FeatureFlagRolloutController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FeatureFlagRolloutController {
 
   @GetMapping("/test/rollout")
-  @FeatureFlag(value = "rollout-feature", rollout = 50)
+  @FeatureFlag("rollout-feature")
   public String testRollout() {
     return "Allowed";
   }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/autoconfigure/FeatureFlagMvcAutoConfiguration.java
@@ -12,7 +12,9 @@ import net.brightroom.featureflag.core.evaluation.FeatureFlagEvaluationPipeline;
 import net.brightroom.featureflag.core.evaluation.RolloutEvaluationStep;
 import net.brightroom.featureflag.core.evaluation.ScheduleEvaluationStep;
 import net.brightroom.featureflag.core.properties.FeatureFlagProperties;
+import net.brightroom.featureflag.core.provider.ConditionProvider;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
+import net.brightroom.featureflag.core.provider.InMemoryConditionProvider;
 import net.brightroom.featureflag.core.provider.InMemoryFeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.InMemoryRolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.InMemoryScheduleProvider;
@@ -82,6 +84,12 @@ public class FeatureFlagMvcAutoConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean(ConditionProvider.class)
+  ConditionProvider conditionProvider() {
+    return new InMemoryConditionProvider(featureFlagProperties.conditions());
+  }
+
+  @Bean
   @ConditionalOnMissingBean
   FeatureFlagConditionEvaluator featureFlagConditionEvaluator() {
     return new SpelFeatureFlagConditionEvaluator(featureFlagProperties.condition().failOnError());
@@ -134,8 +142,10 @@ public class FeatureFlagMvcAutoConfiguration {
   FeatureFlagInterceptor featureFlagInterceptor(
       FeatureFlagEvaluationPipeline pipeline,
       RolloutPercentageProvider rolloutPercentageProvider,
+      ConditionProvider conditionProvider,
       FeatureFlagContextResolver contextResolver) {
-    return new FeatureFlagInterceptor(pipeline, rolloutPercentageProvider, contextResolver);
+    return new FeatureFlagInterceptor(
+        pipeline, rolloutPercentageProvider, conditionProvider, contextResolver);
   }
 
   @Bean
@@ -156,9 +166,14 @@ public class FeatureFlagMvcAutoConfiguration {
       FeatureFlagEvaluationPipeline pipeline,
       AccessDeniedHandlerFilterResolution accessDeniedHandlerFilterResolution,
       RolloutPercentageProvider rolloutPercentageProvider,
+      ConditionProvider conditionProvider,
       FeatureFlagContextResolver contextResolver) {
     return new FeatureFlagHandlerFilterFunction(
-        pipeline, accessDeniedHandlerFilterResolution, rolloutPercentageProvider, contextResolver);
+        pipeline,
+        accessDeniedHandlerFilterResolution,
+        rolloutPercentageProvider,
+        conditionProvider,
+        contextResolver);
   }
 
   /**

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunction.java
@@ -4,6 +4,7 @@ import net.brightroom.featureflag.core.evaluation.AccessDecision;
 import net.brightroom.featureflag.core.evaluation.EvaluationContext;
 import net.brightroom.featureflag.core.evaluation.FeatureFlagEvaluationPipeline;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ConditionProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.webmvc.condition.HttpServletConditionVariables;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -33,17 +34,21 @@ import org.springframework.web.servlet.function.ServerResponse;
  * The default response format follows {@code feature-flags.response.type} configuration, and can be
  * customized by providing a custom {@link AccessDeniedHandlerFilterResolution} bean.
  *
- * <p>Use {@link #of(String, int)} to enable gradual rollout for functional endpoints.
+ * <p>Use {@link #of(String, int)} to enable gradual rollout for functional endpoints with a
+ * fallback rollout percentage.
  */
 public class FeatureFlagHandlerFilterFunction {
 
   private final FeatureFlagEvaluationPipeline pipeline;
   private final AccessDeniedHandlerFilterResolution resolution;
   private final RolloutPercentageProvider rolloutPercentageProvider;
+  private final ConditionProvider conditionProvider;
   private final FeatureFlagContextResolver contextResolver;
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag.
+   *
+   * <p>Condition and rollout percentage are resolved from the configured providers.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
@@ -55,23 +60,29 @@ public class FeatureFlagHandlerFilterFunction {
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
-   * and SpEL condition expression.
+   * and fallback condition expression.
+   *
+   * <p>The condition is resolved from the provider first; the {@code conditionFallback} is used
+   * only when the provider returns no value for the feature.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
-   * @param condition SpEL expression evaluated against request context; empty string means no
-   *     condition
+   * @param conditionFallback SpEL expression used as fallback when the provider has no condition
+   *     configured; empty string means no condition
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag
    *     and condition
    * @throws IllegalArgumentException if {@code featureName} is null or blank
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
-      String featureName, String condition) {
-    return of(featureName, condition, 100);
+      String featureName, String conditionFallback) {
+    return of(featureName, conditionFallback, 100);
   }
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag
-   * and rollout percentage.
+   * and fallback rollout percentage.
+   *
+   * <p>The rollout percentage is resolved from the provider first; the {@code rolloutFallback} is
+   * used only when the provider returns no value for the feature.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
@@ -88,14 +99,17 @@ public class FeatureFlagHandlerFilterFunction {
 
   /**
    * Creates a {@link HandlerFilterFunction} that guards the route with the specified feature flag,
-   * SpEL condition expression, and rollout percentage.
+   * fallback SpEL condition expression, and fallback rollout percentage.
+   *
+   * <p>The condition and rollout percentage are resolved from their respective providers first;
+   * fallback values are used only when the providers return no value for the feature.
    *
    * <p>The evaluation order is: feature enabled check → schedule check → condition check → rollout
    * check.
    *
    * @param featureName the name of the feature flag to check; must not be null or blank
-   * @param condition SpEL expression evaluated against request context; empty string means no
-   *     condition
+   * @param conditionFallback SpEL expression used as fallback when the provider has no condition
+   *     configured; empty string means no condition
    * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
    *     the provider; 100 means fully enabled
    * @return a {@link HandlerFilterFunction} that allows or denies access based on the feature flag,
@@ -104,7 +118,7 @@ public class FeatureFlagHandlerFilterFunction {
    *     rolloutFallback} is not between 0 and 100
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
-      String featureName, String condition, int rolloutFallback) {
+      String featureName, String conditionFallback, int rolloutFallback) {
     if (featureName == null || featureName.isBlank()) {
       throw new IllegalArgumentException(
           "featureName must not be null or blank. "
@@ -115,6 +129,7 @@ public class FeatureFlagHandlerFilterFunction {
           "rollout must be between 0 and 100, but was: " + rolloutFallback);
     }
     return (request, next) -> {
+      String condition = conditionProvider.getCondition(featureName).orElse(conditionFallback);
       int rollout =
           rolloutPercentageProvider.getRolloutPercentage(featureName).orElse(rolloutFallback);
       EvaluationContext context =
@@ -140,6 +155,8 @@ public class FeatureFlagHandlerFilterFunction {
    * @param resolution the resolution strategy invoked when access is denied; must not be null
    * @param rolloutPercentageProvider the provider used to look up the rollout percentage per
    *     feature; must not be null
+   * @param conditionProvider the provider used to look up the condition expression per feature;
+   *     must not be null
    * @param contextResolver the resolver used to obtain the feature flag context from the request;
    *     must not be null
    */
@@ -147,10 +164,12 @@ public class FeatureFlagHandlerFilterFunction {
       FeatureFlagEvaluationPipeline pipeline,
       AccessDeniedHandlerFilterResolution resolution,
       RolloutPercentageProvider rolloutPercentageProvider,
+      ConditionProvider conditionProvider,
       FeatureFlagContextResolver contextResolver) {
     this.pipeline = pipeline;
     this.resolution = resolution;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionProvider = conditionProvider;
     this.contextResolver = contextResolver;
   }
 }

--- a/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
+++ b/webmvc/src/main/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptor.java
@@ -7,6 +7,7 @@ import net.brightroom.featureflag.core.evaluation.AccessDecision;
 import net.brightroom.featureflag.core.evaluation.EvaluationContext;
 import net.brightroom.featureflag.core.evaluation.FeatureFlagEvaluationPipeline;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ConditionProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.webmvc.condition.HttpServletConditionVariables;
 import net.brightroom.featureflag.webmvc.context.FeatureFlagContextResolver;
@@ -27,23 +28,28 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
 
   private final FeatureFlagEvaluationPipeline pipeline;
   private final RolloutPercentageProvider rolloutPercentageProvider;
+  private final ConditionProvider conditionProvider;
   private final FeatureFlagContextResolver contextResolver;
 
   /**
    * Creates a new {@link FeatureFlagInterceptor}.
    *
    * @param pipeline the evaluation pipeline that performs all feature flag checks; must not be null
-   * @param rolloutPercentageProvider the provider that supplies per-flag rollout percentages,
-   *     overriding annotation-level values when present; must not be null
+   * @param rolloutPercentageProvider the provider that supplies per-flag rollout percentages; must
+   *     not be null
+   * @param conditionProvider the provider that supplies per-flag condition expressions; must not be
+   *     null
    * @param contextResolver the resolver used to obtain the feature flag context from the request;
    *     must not be null
    */
   public FeatureFlagInterceptor(
       FeatureFlagEvaluationPipeline pipeline,
       RolloutPercentageProvider rolloutPercentageProvider,
+      ConditionProvider conditionProvider,
       FeatureFlagContextResolver contextResolver) {
     this.pipeline = pipeline;
     this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionProvider = conditionProvider;
     this.contextResolver = contextResolver;
   }
 
@@ -86,19 +92,15 @@ public class FeatureFlagInterceptor implements HandlerInterceptor {
           "@FeatureFlag must specify a non-empty value. "
               + "An empty value causes fail-open behavior and allows access unconditionally.");
     }
-    if (annotation.rollout() < 0 || annotation.rollout() > 100) {
-      throw new IllegalStateException(
-          "@FeatureFlag rollout must be between 0 and 100, but was: " + annotation.rollout());
-    }
   }
 
   private EvaluationContext buildContext(HttpServletRequest request, FeatureFlag annotation) {
     String featureName = annotation.value();
-    int rollout =
-        rolloutPercentageProvider.getRolloutPercentage(featureName).orElse(annotation.rollout());
+    String condition = conditionProvider.getCondition(featureName).orElse("");
+    int rollout = rolloutPercentageProvider.getRolloutPercentage(featureName).orElse(100);
     return new EvaluationContext(
         featureName,
-        annotation.condition(),
+        condition,
         rollout,
         HttpServletConditionVariables.build(request),
         () -> contextResolver.resolve(request).orElse(null));

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/filter/FeatureFlagHandlerFilterFunctionTest.java
@@ -27,6 +27,7 @@ import net.brightroom.featureflag.core.evaluation.FeatureFlagEvaluationPipeline;
 import net.brightroom.featureflag.core.evaluation.RolloutEvaluationStep;
 import net.brightroom.featureflag.core.evaluation.ScheduleEvaluationStep;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ConditionProvider;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.Schedule;
@@ -49,6 +50,8 @@ class FeatureFlagHandlerFilterFunctionTest {
   private final FeatureFlagContextResolver contextResolver = mock(FeatureFlagContextResolver.class);
   private final RolloutPercentageProvider rolloutPercentageProvider =
       mock(RolloutPercentageProvider.class);
+  private final ConditionProvider conditionProvider =
+      mock(ConditionProvider.class, invocation -> Optional.empty());
   private final FeatureFlagConditionEvaluator conditionEvaluator =
       mock(FeatureFlagConditionEvaluator.class);
   private final ScheduleProvider scheduleProvider =
@@ -64,7 +67,7 @@ class FeatureFlagHandlerFilterFunctionTest {
             new RolloutEvaluationStep(strategy));
     FeatureFlagEvaluationPipeline pipeline = new FeatureFlagEvaluationPipeline(steps);
     return new FeatureFlagHandlerFilterFunction(
-        pipeline, resolution, rolloutPercentageProvider, contextResolver);
+        pipeline, resolution, rolloutPercentageProvider, conditionProvider, contextResolver);
   }
 
   private final FeatureFlagHandlerFilterFunction filterFunction =
@@ -443,7 +446,7 @@ class FeatureFlagHandlerFilterFunctionTest {
     FeatureFlagEvaluationPipeline pipeline = mock(FeatureFlagEvaluationPipeline.class);
     FeatureFlagHandlerFilterFunction filterFn =
         new FeatureFlagHandlerFilterFunction(
-            pipeline, resolution, rolloutPercentageProvider, contextResolver);
+            pipeline, resolution, rolloutPercentageProvider, conditionProvider, contextResolver);
 
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
         .thenReturn(OptionalInt.empty());

--- a/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
+++ b/webmvc/src/test/java/net/brightroom/featureflag/webmvc/interceptor/FeatureFlagInterceptorTest.java
@@ -27,6 +27,7 @@ import net.brightroom.featureflag.core.evaluation.FeatureFlagEvaluationPipeline;
 import net.brightroom.featureflag.core.evaluation.RolloutEvaluationStep;
 import net.brightroom.featureflag.core.evaluation.ScheduleEvaluationStep;
 import net.brightroom.featureflag.core.exception.FeatureFlagAccessDeniedException;
+import net.brightroom.featureflag.core.provider.ConditionProvider;
 import net.brightroom.featureflag.core.provider.FeatureFlagProvider;
 import net.brightroom.featureflag.core.provider.RolloutPercentageProvider;
 import net.brightroom.featureflag.core.provider.Schedule;
@@ -46,6 +47,7 @@ class FeatureFlagInterceptorTest {
   private final FeatureFlagContextResolver contextResolver = mock(FeatureFlagContextResolver.class);
   private final RolloutPercentageProvider rolloutPercentageProvider =
       mock(RolloutPercentageProvider.class);
+  private final ConditionProvider conditionProvider = mock(ConditionProvider.class);
   private final FeatureFlagConditionEvaluator conditionEvaluator =
       mock(FeatureFlagConditionEvaluator.class);
   private final ScheduleProvider scheduleProvider =
@@ -59,7 +61,8 @@ class FeatureFlagInterceptorTest {
             new ConditionEvaluationStep(conditionEvaluator),
             new RolloutEvaluationStep(rolloutStrategy));
     FeatureFlagEvaluationPipeline pipeline = new FeatureFlagEvaluationPipeline(steps);
-    return new FeatureFlagInterceptor(pipeline, rolloutPercentageProvider, contextResolver);
+    return new FeatureFlagInterceptor(
+        pipeline, rolloutPercentageProvider, conditionProvider, contextResolver);
   }
 
   private final HttpServletRequest request = mock(HttpServletRequest.class);
@@ -70,6 +73,7 @@ class FeatureFlagInterceptorTest {
     // EvaluationContext is always built eagerly, so stub request and default dependencies
     stubRequestForConditionVariables();
     when(rolloutPercentageProvider.getRolloutPercentage(any())).thenReturn(OptionalInt.empty());
+    when(conditionProvider.getCondition(any())).thenReturn(Optional.empty());
     when(contextResolver.resolve(request)).thenReturn(Optional.empty());
   }
 
@@ -79,15 +83,9 @@ class FeatureFlagInterceptorTest {
     return handlerMethod;
   }
 
-  private FeatureFlag featureFlagAnnotation(String value, int rollout) {
-    return featureFlagAnnotation(value, "", rollout);
-  }
-
-  private FeatureFlag featureFlagAnnotation(String value, String condition, int rollout) {
+  private FeatureFlag featureFlagAnnotation(String value) {
     FeatureFlag annotation = mock(FeatureFlag.class);
     when(annotation.value()).thenReturn(value);
-    when(annotation.condition()).thenReturn(condition);
-    when(annotation.rollout()).thenReturn(rollout);
     return annotation;
   }
 
@@ -96,7 +94,7 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_throwsFeatureFlagAccessDeniedException_whenScheduleIsInactive() {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
@@ -109,7 +107,7 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_returnsTrue_whenScheduleIsActive() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
@@ -127,7 +125,7 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_throwsIllegalStateException_whenFeatureFlagValueIsEmpty() {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("", 100);
+    FeatureFlag annotation = featureFlagAnnotation("");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
 
     assertThatIllegalStateException()
@@ -135,34 +133,12 @@ class FeatureFlagInterceptorTest {
         .withMessageContaining("non-empty value");
   }
 
-  @Test
-  void preHandle_throwsIllegalStateException_whenRolloutIsNegative() {
-    FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", -1);
-    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
-
-    assertThatIllegalStateException()
-        .isThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
-        .withMessageContaining("rollout must be between 0 and 100");
-  }
-
-  @Test
-  void preHandle_throwsIllegalStateException_whenRolloutIsOver100() {
-    FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 101);
-    HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
-
-    assertThatIllegalStateException()
-        .isThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
-        .withMessageContaining("rollout must be between 0 and 100");
-  }
-
   // --- checkRollout ---
 
   @Test
   void preHandle_returnsTrue_whenRolloutIs100() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
@@ -176,11 +152,11 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_returnsTrue_whenContextPresentAndInsideRollout() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 50);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
-        .thenReturn(OptionalInt.empty());
+        .thenReturn(OptionalInt.of(50));
     FeatureFlagContext context = new FeatureFlagContext("user-1");
     when(contextResolver.resolve(request)).thenReturn(Optional.of(context));
     when(rolloutStrategy.isInRollout("my-feature", context, 50)).thenReturn(true);
@@ -193,11 +169,11 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_throwsFeatureFlagAccessDeniedException_whenContextPresentAndOutsideRollout() {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 50);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
-        .thenReturn(OptionalInt.empty());
+        .thenReturn(OptionalInt.of(50));
     FeatureFlagContext context = new FeatureFlagContext("user-1");
     when(contextResolver.resolve(request)).thenReturn(Optional.of(context));
     when(rolloutStrategy.isInRollout("my-feature", context, 50)).thenReturn(false);
@@ -209,11 +185,11 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_returnsTrue_whenContextIsEmpty() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 50);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
-        .thenReturn(OptionalInt.empty());
+        .thenReturn(OptionalInt.of(50));
     when(contextResolver.resolve(request)).thenReturn(Optional.empty());
 
     boolean result = interceptor.preHandle(request, response, handlerMethod);
@@ -246,11 +222,11 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_throwsFeatureFlagAccessDeniedException_whenRolloutIsZero() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 0);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
-        .thenReturn(OptionalInt.empty());
+        .thenReturn(OptionalInt.of(0));
     FeatureFlagContext context = new FeatureFlagContext("user-1");
     when(contextResolver.resolve(request)).thenReturn(Optional.of(context));
     when(rolloutStrategy.isInRollout("my-feature", context, 0)).thenReturn(false);
@@ -261,7 +237,7 @@ class FeatureFlagInterceptorTest {
 
   // --- class-level @FeatureFlag + rollout ---
 
-  @FeatureFlag(value = "my-feature", rollout = 50)
+  @FeatureFlag("my-feature")
   static class RolloutAnnotatedController {}
 
   private HandlerMethod handlerMethodWithClassAnnotation() {
@@ -278,7 +254,7 @@ class FeatureFlagInterceptorTest {
     HandlerMethod handlerMethod = handlerMethodWithClassAnnotation();
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
-        .thenReturn(OptionalInt.empty());
+        .thenReturn(OptionalInt.of(50));
     FeatureFlagContext context = new FeatureFlagContext("user-1");
     when(contextResolver.resolve(request)).thenReturn(Optional.of(context));
     when(rolloutStrategy.isInRollout("my-feature", context, 50)).thenReturn(true);
@@ -295,7 +271,7 @@ class FeatureFlagInterceptorTest {
     HandlerMethod handlerMethod = handlerMethodWithClassAnnotation();
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
-        .thenReturn(OptionalInt.empty());
+        .thenReturn(OptionalInt.of(50));
     FeatureFlagContext context = new FeatureFlagContext("user-1");
     when(contextResolver.resolve(request)).thenReturn(Optional.of(context));
     when(rolloutStrategy.isInRollout("my-feature", context, 50)).thenReturn(false);
@@ -318,11 +294,13 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_returnsTrue_whenConditionIsTrue() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", "headers['X-Beta'] != null", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
         .thenReturn(OptionalInt.empty());
+    when(conditionProvider.getCondition("my-feature"))
+        .thenReturn(Optional.of("headers['X-Beta'] != null"));
     stubRequestForConditionVariables();
     when(conditionEvaluator.evaluate(
             org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
@@ -337,9 +315,11 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_throwsFeatureFlagAccessDeniedException_whenConditionIsFalse() {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", "headers['X-Beta'] != null", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(conditionProvider.getCondition("my-feature"))
+        .thenReturn(Optional.of("headers['X-Beta'] != null"));
     stubRequestForConditionVariables();
     when(conditionEvaluator.evaluate(
             org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
@@ -353,11 +333,12 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_skipsConditionCheck_whenConditionIsEmpty() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", "", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
         .thenReturn(OptionalInt.empty());
+    when(conditionProvider.getCondition("my-feature")).thenReturn(Optional.empty());
 
     boolean result = interceptor.preHandle(request, response, handlerMethod);
 
@@ -367,9 +348,11 @@ class FeatureFlagInterceptorTest {
   @Test
   void preHandle_evaluatesConditionBeforeRollout() throws Exception {
     FeatureFlagInterceptor interceptor = buildInterceptor();
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", "headers['X-Beta'] != null", 50);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(provider.isFeatureEnabled("my-feature")).thenReturn(true);
+    when(conditionProvider.getCondition("my-feature"))
+        .thenReturn(Optional.of("headers['X-Beta'] != null"));
     stubRequestForConditionVariables();
     when(conditionEvaluator.evaluate(
             org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
@@ -386,12 +369,14 @@ class FeatureFlagInterceptorTest {
   void preHandle_delegatesToPipeline_whenDecisionIsAllowed() throws Exception {
     FeatureFlagEvaluationPipeline pipeline = mock(FeatureFlagEvaluationPipeline.class);
     FeatureFlagInterceptor interceptor =
-        new FeatureFlagInterceptor(pipeline, rolloutPercentageProvider, contextResolver);
+        new FeatureFlagInterceptor(
+            pipeline, rolloutPercentageProvider, conditionProvider, contextResolver);
 
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
         .thenReturn(OptionalInt.empty());
+    when(conditionProvider.getCondition("my-feature")).thenReturn(Optional.empty());
     when(contextResolver.resolve(request)).thenReturn(Optional.empty());
     when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
     when(request.getParameterMap()).thenReturn(Map.of());
@@ -411,12 +396,14 @@ class FeatureFlagInterceptorTest {
   void preHandle_throwsException_whenPipelineReturnsDenied() {
     FeatureFlagEvaluationPipeline pipeline = mock(FeatureFlagEvaluationPipeline.class);
     FeatureFlagInterceptor interceptor =
-        new FeatureFlagInterceptor(pipeline, rolloutPercentageProvider, contextResolver);
+        new FeatureFlagInterceptor(
+            pipeline, rolloutPercentageProvider, conditionProvider, contextResolver);
 
-    FeatureFlag annotation = featureFlagAnnotation("my-feature", 100);
+    FeatureFlag annotation = featureFlagAnnotation("my-feature");
     HandlerMethod handlerMethod = handlerMethodWithAnnotation(annotation);
     when(rolloutPercentageProvider.getRolloutPercentage("my-feature"))
         .thenReturn(OptionalInt.empty());
+    when(conditionProvider.getCondition("my-feature")).thenReturn(Optional.empty());
     when(contextResolver.resolve(request)).thenReturn(Optional.empty());
     when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
     when(request.getParameterMap()).thenReturn(Map.of());


### PR DESCRIPTION
## Summary

- Remove `condition` and `rollout` attributes from `@FeatureFlag` annotation; the annotation now only has `value`
- Both are now configured via `feature-flags.features.<name>.condition` and `feature-flags.features.<name>.rollout` in YAML, consistent with `enabled` and `schedule`
- Introduce `ConditionProvider` / `ReactiveConditionProvider` SPI (+ mutable and in-memory variants) following the same pattern as `RolloutPercentageProvider`
- Actuator endpoint gains condition CRUD: `GET /actuator/feature-flags/{name}` includes `condition`, `POST` accepts `condition` param, `DELETE` removes condition
- `FeatureFlagChangedEvent` extended with `condition` field
- `feature-flags.features.[*].condition` property metadata added to `additional-spring-configuration-metadata.json`
- All tests (unit + integration) updated to configure condition/rollout via providers and YAML properties instead of annotation attributes

## Test plan

- [x] `./gradlew check` passes (all unit + integration tests green, spotless clean)
- [x] `FeatureFlagAspectTest` — rollout tests stub `rolloutPercentageProvider`, condition tests stub `conditionProvider`
- [x] `FeatureFlagInterceptorTest` — same pattern for webmvc
- [x] `FeatureFlagEndpointTest` / `ReactiveFeatureFlagEndpointTest` — updated for 7-arg constructor and 4-arg `updateFeature`
- [x] Integration tests use `@TestPropertySource` / `@SpringBootTest(properties=...)` to configure conditions and rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)